### PR TITLE
Add keccak256 precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +316,7 @@ version = "0.0.0"
 dependencies = [
  "byteorder",
  "rand",
+ "tiny-keccak",
  "wasmi",
 ]
 
@@ -328,6 +335,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/starstream_sys/src/lib.rs
+++ b/starstream_sys/src/lib.rs
@@ -92,7 +92,7 @@ unsafe extern "C" {
     pub safe fn this_code() -> CodeHash;
 
     #[link_name = "starstream_keccak256"]
-    fn preocompile_keccak256(buf: *const u8, len: usize, result: *mut u8);
+    fn precompile_keccak256(buf: *const u8, len: usize, result: *mut u8);
 }
 
 #[inline]
@@ -103,7 +103,7 @@ pub fn log(buf: &[u8]) {
 #[inline]
 pub fn keccak256(buf: &[u8]) -> [u8; 32] {
     let mut out = [0u8; 32];
-    unsafe { preocompile_keccak256(buf.as_ptr(), buf.len(), out.as_mut_slice().as_mut_ptr()) };
+    unsafe { precompile_keccak256(buf.as_ptr(), buf.len(), out.as_mut_slice().as_mut_ptr()) };
     out
 }
 

--- a/starstream_sys/src/lib.rs
+++ b/starstream_sys/src/lib.rs
@@ -97,6 +97,21 @@ pub fn log(buf: &[u8]) {
     unsafe { starstream_log(buf.as_ptr(), buf.len()) }
 }
 
+// ----------------------------------------------------------------------------
+// Common import environment for precompiles, separated from "env" just for namespacing reasons.
+#[link(wasm_import_module = "precompiles")]
+unsafe extern "C" {
+    #[link_name = "starstream_precompiles_keccak256"]
+    fn preocompiles_keccak256(buf: *const u8, len: usize, result: *mut u8);
+}
+
+#[inline]
+pub fn keccak256(buf: &[u8]) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    unsafe { preocompiles_keccak256(buf.as_ptr(), buf.len(), out.as_mut_slice().as_mut_ptr()) };
+    out
+}
+
 pub fn panic_handler(_: &PanicInfo) -> ! {
     unsafe {
         abort();

--- a/starstream_sys/src/lib.rs
+++ b/starstream_sys/src/lib.rs
@@ -90,6 +90,9 @@ unsafe extern "C" {
 
     #[link_name = "starstream_this_code"]
     pub safe fn this_code() -> CodeHash;
+
+    #[link_name = "starstream_keccak256"]
+    fn preocompile_keccak256(buf: *const u8, len: usize, result: *mut u8);
 }
 
 #[inline]
@@ -97,18 +100,10 @@ pub fn log(buf: &[u8]) {
     unsafe { starstream_log(buf.as_ptr(), buf.len()) }
 }
 
-// ----------------------------------------------------------------------------
-// Common import environment for precompiles, separated from "env" just for namespacing reasons.
-#[link(wasm_import_module = "precompiles")]
-unsafe extern "C" {
-    #[link_name = "starstream_precompiles_keccak256"]
-    fn preocompiles_keccak256(buf: *const u8, len: usize, result: *mut u8);
-}
-
 #[inline]
 pub fn keccak256(buf: &[u8]) -> [u8; 32] {
     let mut out = [0u8; 32];
-    unsafe { preocompiles_keccak256(buf.as_ptr(), buf.len(), out.as_mut_slice().as_mut_ptr()) };
+    unsafe { preocompile_keccak256(buf.as_ptr(), buf.len(), out.as_mut_slice().as_mut_ptr()) };
     out
 }
 

--- a/starstream_vm/Cargo.toml
+++ b/starstream_vm/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2024"
 byteorder = "1.5.0"
 rand = "0.9.0"
 wasmi = "0.31.0"
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 #zk-engine = { git = "https://github.com/ICME-Lab/zkEngine_dev", branch = "main" }

--- a/starstream_vm/src/lib.rs
+++ b/starstream_vm/src/lib.rs
@@ -140,14 +140,10 @@ fn starstream_env<T>(
             },
         )
         .unwrap();
-}
-
-/// Fulfiller of imports from `precompiles`.
-fn starstream_precompiles<T>(linker: &mut Linker<T>) {
     linker
         .func_wrap(
-            "precompiles",
-            "starstream_precompiles_keccak256",
+            module,
+            "starstream_keccak256",
             |mut caller: Caller<T>, ptr: u32, len: u32, return_addr: u32| {
                 let mut hasher = tiny_keccak::Keccak::v256();
 
@@ -271,8 +267,6 @@ fn utxo_linker(
     starstream_env(&mut linker, "env", utxo_code, |instance: &UtxoInstance| {
         &instance.coordination_code
     });
-
-    starstream_precompiles(&mut linker);
 
     starstream_utxo_env(&mut linker, "starstream_utxo_env");
 
@@ -660,8 +654,6 @@ fn coordination_script_linker<'tx>(
         &coordination_code,
         |env: &CoordinationScriptInstance| &env.coordination_code,
     );
-
-    starstream_precompiles(&mut linker);
 
     for import in coordination_code.module(&engine).imports() {
         if import.module() == "env" {


### PR DESCRIPTION
Part of #3 

Adds a way to call a built-in keccak through the vm.

I tested this by just calling the function through a few places in the example contract, but I didn't include that code here because it doesn't really make much sense.

I'm not sure how to test it properly otherwise, does it fit somewhere in the existing contract or would we need a different test (but I don't see any unit tests).

~Also I'm not sure if putting these in their own module makes sense, but it just feels like the `env` module is too generic (or maybe it's just the name that's confusing?).~ Changed my mind about this, although I still think "env" is a weird name for the shared module.