### PR TITLE
setup tree-sitter grammar and highlighting query

### DIFF
--- a/tree-sitter-starstream/.editorconfig
+++ b/tree-sitter-starstream/.editorconfig
@@ -1,0 +1,46 @@
+root = true
+
+[*]
+charset = utf-8
+
+[*.{json,toml,yml,gyp}]
+indent_style = space
+indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.scm]
+indent_style = space
+indent_size = 2
+
+[*.{c,cc,h}]
+indent_style = space
+indent_size = 4
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.{py,pyi}]
+indent_style = space
+indent_size = 4
+
+[*.swift]
+indent_style = space
+indent_size = 4
+
+[*.go]
+indent_style = tab
+indent_size = 8
+
+[Makefile]
+indent_style = tab
+indent_size = 8
+
+[parser.c]
+indent_size = 2
+
+[{alloc,array,parser}.h]
+indent_size = 2

--- a/tree-sitter-starstream/.gitignore
+++ b/tree-sitter-starstream/.gitignore
@@ -1,0 +1,40 @@
+# Rust artifacts
+target/
+
+# Node artifacts
+build/
+prebuilds/
+node_modules/
+
+# Swift artifacts
+.build/
+
+# Go artifacts
+_obj/
+
+# Python artifacts
+.venv/
+dist/
+*.egg-info
+*.whl
+
+# C artifacts
+*.a
+*.so
+*.so.*
+*.dylib
+*.dll
+*.pc
+
+# Example dirs
+/examples/*/
+
+# Grammar volatiles
+*.wasm
+*.obj
+*.o
+
+# Archives
+*.tar.gz
+*.tgz
+*.zip

--- a/tree-sitter-starstream/grammar.js
+++ b/tree-sitter-starstream/grammar.js
@@ -1,0 +1,251 @@
+module.exports = grammar({
+  name: 'starstream',
+
+  extras: $ => [
+    $._whitespace,
+    $.comment,
+    $.commentLine
+  ],
+
+  rules: {
+    Program: $ => seq(
+      repeat(choice($.Utxo, $.Script, $.Token))
+    ),
+
+    Utxo: $ => seq(
+      'utxo',
+      $.Type,
+      '{',
+      repeat(choice($.Abi, $.Main, $.Impl, $.Storage)),
+      '}'
+    ),
+
+    Script: $ => seq(
+      'script',
+      '{',
+      repeat($.FnDef),
+      '}'
+    ),
+
+    Token: $ => seq(
+      'token',
+      $.ident,
+      '{',
+      repeat(choice($.Abi, $.Bind, $.Unbind, $.Mint)),
+      '}'
+    ),
+
+    Abi: $ => seq(
+      'abi',
+      '{',
+      repeat(seq(choice($.FnSig, $.EffectSig), ';')),
+      '}'
+    ),
+
+    Impl: $ => seq(
+      'impl',
+      $.Type,
+      '{',
+      repeat($.FnDef),
+      '}'
+    ),
+
+    Main: $ => seq(
+      'main',
+      optional(seq('(', $.TypedBindings, ')')),
+      $.Block
+    ),
+
+    Storage: $ => seq(
+      'storage',
+      '{',
+      repeat(seq($.TypedBinding, ';')),
+      '}'
+    ),
+
+    Bind: $ => seq(
+      'bind',
+      $.Block
+    ),
+
+    Unbind: $ => seq(
+      'unbind',
+      $.Block
+    ),
+
+    Mint: $ => seq(
+      'mint',
+      $.Block
+    ),
+
+    TypedBinding: $ => seq(
+      $.ident,
+      optional(seq(':', $.Type))
+    ),
+
+    TypedBindings: $ =>
+      seq(
+        $.TypedBinding,
+        repeat(seq(',', $.TypedBinding)),
+        optional(',')
+      )
+    ,
+
+    FnDef: $ => seq(
+      'fn',
+      $.ident,
+      '(',
+      optional($.TypedBindings),
+      ')',
+      optional(seq(':', $.Type)),
+      $.Block
+    ),
+
+    EffectBlock: $ => seq($.Effect, $.Block),
+
+    Statement: $ => choice(
+      $.BindVar,
+      seq($.returnLike, optional($.Expr), ';'),
+      seq($.Assign, ';'),
+      seq('try', $.Block, repeat1(seq('with', $.EffectBlock))),
+      seq('while', '(', $.Expr, ')', $.LoopBody),
+      seq('loop', $.LoopBody)
+    ),
+
+    Assign: $ => seq(
+      $.ident,
+      '=',
+      $.Expr
+    ),
+
+    BindVar: $ => seq(
+      choice('let', 'let mut'),
+      $.ident,
+      optional(seq(':', $.Type)),
+      '=',
+      $.Expr,
+      ';'
+    ),
+
+    LoopBody: $ => choice(
+      $.Statement,
+      seq($.Block),
+      seq($.Expr, ';')
+    ),
+
+    Effect: $ => seq(
+      $.Type,
+      '(',
+      $.TypedBindings,
+      ')'
+    ),
+
+    Block: $ => 
+      seq(
+        '{',
+        seq(repeat(choice($.Statement, seq($.IfExpr, optional(';')), seq($.Expr, ';'))), optional($.Expr)),
+        '}'
+    ),
+
+    Expr: $ => prec.left(1, choice(
+      seq($.PrimaryExpr, optional($.InfixOpTail)),
+      seq('!', $.Expr),
+      seq($.yield, optional($.Expr))
+    )),
+
+    InfixOpTail: $ => seq(
+      $.InfixOp,
+      $.Expr
+    ),
+
+    PrimaryExpr: $ => prec.left(1, choice(
+      $.number,
+      $.bool,
+      $.stringLiteral,
+      seq(repeat(seq($.Type, '::')), $.ident, optional($.Arguments)),
+      seq('(', $.Expr, ')'),
+      $.Block,
+      $.IfExpr,
+      $.ObjectLiteral,
+    )),
+
+    ObjectLiteral: $ => seq(
+      $.Type,
+      '{',
+        seq(
+          seq($.ident, ':', $.Expr),
+          repeat(seq(',', $.ident, ':', $.Expr)),
+          optional(',')
+        ),
+      '}'
+     ),
+
+    IfExpr: $ => prec.left(1, seq(
+      'if',
+      '(',
+      $.Expr,
+      ')',
+      $.Block,
+      optional(seq('else', $.Block))
+    )),
+
+    Arguments: $ => seq(
+      '(',
+      optional(seq($.Expr, repeat(seq(',', $.Expr)))),
+      ')'
+    ),
+
+    InfixOp: $ => choice(
+      '+', '*', '==', '<', '<=', '>=', '!=', '&&', '||', '.', '-'
+    ),
+
+    Sig: $ => seq(
+      $.ident,
+      '(',
+      optional(seq($.Type, repeat(seq(',', $.Type)))),
+      ')',
+      optional(seq(':', $.Type))
+    ),
+
+    FnSig: $ => seq(
+      'fn',
+      $.Sig
+    ),
+
+    EffectSigType: $ => seq(
+      $.Type,
+      '(',
+      optional(seq($.Type, repeat(seq(',', $.Type)))),
+      ')',
+      optional(seq(':', $.Type))
+    ),
+
+    EffectSig: $ => seq(
+      choice('effect', 'event', 'error'),
+      $.EffectSigType
+    ),
+
+    Type: $ => choice(
+      seq('(', $.TypedBindings, ')', optional(seq('->', $.Type))),
+      seq('&', $.Type),
+      seq('{', $.TypedBindings, '}'),
+      seq($.ident, optional(seq('<', $.Type, repeat(seq(',', $.Type)), '>')))
+    ),
+
+    // Terminals
+    ident: $ => {
+      const identifier = /[a-zA-Z]([a-zA-Z0-9]|_)+|[a-zA-Z]/;
+      return token(prec(-1, new RegExp(identifier.source)));
+    },
+    _whitespace: $ => /[\t\n\r ]+/,
+    number: $ => /0|-?[1-9]([0-9]|_)*(\.[0-9]*)?/,
+    stringLiteral: $ => /"[^"]*"/,
+    yield: $ => choice('yield', 'raise', 'fail'),
+    returnLike: $ => choice('resume', 'return'),
+    bool: $ => choice($.true, $.false),
+    true: $ => 'true',
+    false: $ => 'false',
+    comment: $ => /\/\*[^*]*\*+([^/*][^*]*\*+)*\//,
+    commentLine: $ => /\/\/[^\n\r]*/
+  }
+});

--- a/tree-sitter-starstream/queries/highlights.scm
+++ b/tree-sitter-starstream/queries/highlights.scm
@@ -1,0 +1,48 @@
+(Type) @type
+
+(ident) @variable
+
+(FnDef (ident) @function)
+("main") @function
+(comment) @comment
+(commentLine) @comment
+((ident) (Arguments)) @function
+(BindVar (ident) @variable)
+(Type) @type
+(Type (ident) @type)
+(stringLiteral) @string
+(bool) @constant.builtin.boolean
+(number) @constant.numeric.integer
+
+"fn" @keyword
+"return" @keyword
+"yield" @keyword.control
+"resume" @keyword.control
+"return" @keyword
+"loop" @keyword
+"while" @keyword
+"if" @keyword
+"else" @keyword
+"let" @keyword
+"try" @keyword
+"impl" @keyword
+"raise" @keyword.control
+"with" @keyword
+"error" @keyword
+"utxo" @keyword
+"script" @keyword
+"storage" @keyword
+"abi" @keyword
+"bind" @keyword
+"mint" @keyword
+"unbind" @keyword
+"effect" @keyword
+"token" @keyword
+
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+"::" @punctuation.delimiter
+"<" @punctuation.bracket
+">" @punctuation.bracket
+
+(InfixOp) @operator

--- a/tree-sitter-starstream/queries/locals.scm
+++ b/tree-sitter-starstream/queries/locals.scm
@@ -1,0 +1,15 @@
+; locals.scm
+
+[
+(FnDef)
+(Block)
+(EffectBlock)
+] @local.scope
+
+(BindVar (ident) @local.definition)
+
+(FnDef (ident) (TypedBindings (TypedBinding (ident) @local.definition)))
+
+(Effect (Type (ident)) (TypedBindings (TypedBinding (ident) @local.definition)))
+
+(ident) @local.reference

--- a/tree-sitter-starstream/test/corpus/oracle.txt
+++ b/tree-sitter-starstream/test/corpus/oracle.txt
@@ -1,0 +1,108 @@
+==================
+utxo
+==================
+utxo OracleContract {
+  storage {
+    data: Data;
+  }
+
+  main(data: Data) {
+    loop { yield; }
+  }
+
+  impl OracleContract {
+    fn get_data(self): Data {
+        let caller = raise Caller();
+        let this_contract = raise ThisCode();
+
+        if (caller != this_contract) {
+            // oracle data can only be called from a coordination script in
+            // this contract, that ensures data is paid for
+            raise Error("InvalidContext");
+        }
+
+        return self.data; // note: this non-mutable, so it's just a reference input
+    }
+  }
+}
+---
+(Program
+  (Utxo
+    (Type (ident))
+    (Storage
+      (TypedBinding
+        (ident)
+        (Type
+          (ident))))
+    (Main
+      (TypedBindings
+        (TypedBinding
+          (ident)
+          (Type
+            (ident))))
+      (Block
+        (Statement
+          (LoopBody
+            (Block
+              (Expr
+                (yield)))))))
+    (Impl
+      (Type (ident))
+      (FnDef
+        (ident)
+        (TypedBindings
+          (TypedBinding
+            (ident)))
+        (Type
+          (ident))
+        (Block
+          (Statement
+            (BindVar
+              (ident)
+              (Expr
+                (yield)
+                (Expr
+                  (PrimaryExpr
+                    (ident)
+                    (Arguments))))))
+          (Statement
+            (BindVar
+              (ident)
+              (Expr
+                (yield)
+                (Expr
+                  (PrimaryExpr
+                    (ident)
+                    (Arguments))))))
+          (IfExpr
+            (Expr
+              (PrimaryExpr
+                (ident))
+              (InfixOpTail
+                (InfixOp)
+                (Expr
+                  (PrimaryExpr
+                    (ident)))))
+            (Block
+              (commentLine)
+              (commentLine)
+              (Expr
+                (yield)
+                (Expr
+                  (PrimaryExpr
+                    (ident)
+                    (Arguments
+                      (Expr
+                        (PrimaryExpr
+                          (stringLiteral)))))))))
+          (Statement
+            (returnLike)
+            (Expr
+              (PrimaryExpr
+                (ident))
+              (InfixOpTail
+                (InfixOp)
+                (Expr
+                  (PrimaryExpr
+                    (ident))))))
+          (commentLine))))))

--- a/tree-sitter-starstream/test/corpus/script.txt
+++ b/tree-sitter-starstream/test/corpus/script.txt
@@ -1,0 +1,61 @@
+==================
+script
+==================
+script {
+  fn test(input: Value) {
+    yield 1 + 1;
+    yield 3;
+    if(input == 3) {
+      // comment
+      return 4;
+    }
+    yield 5
+  }
+}
+---
+(Program
+  (Script
+    (FnDef
+      (ident)
+      (TypedBindings
+        (TypedBinding
+          (ident)
+          (Type
+            (ident))))
+      (Block
+        (Expr
+          (yield)
+          (Expr
+            (PrimaryExpr
+              (number))
+            (InfixOpTail
+              (InfixOp)
+              (Expr
+                (PrimaryExpr
+                  (number))))))
+        (Expr
+          (yield)
+          (Expr
+            (PrimaryExpr
+              (number))))
+        (IfExpr
+          (Expr
+            (PrimaryExpr
+              (ident))
+            (InfixOpTail
+              (InfixOp)
+              (Expr
+                (PrimaryExpr
+                  (number)))))
+          (Block
+            (commentLine)
+            (Statement
+              (returnLike)
+              (Expr
+                (PrimaryExpr
+                  (number))))))
+        (Expr
+          (yield)
+          (Expr
+            (PrimaryExpr
+              (number))))))))

--- a/tree-sitter-starstream/test/corpus/utxo.txt
+++ b/tree-sitter-starstream/test/corpus/utxo.txt
@@ -1,0 +1,13 @@
+==================
+utxo test
+==================
+utxo Contract { abi {} main {} }
+---
+(Program
+	(Utxo
+		(Type (ident))
+		(Abi)
+		(Main
+			(Block))
+	)
+)

--- a/tree-sitter-starstream/tree-sitter.json
+++ b/tree-sitter-starstream/tree-sitter.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json",
+  "grammars": [
+    {
+      "name": "starstream",
+      "camelcase": "Starstream",
+      "scope": "source.starstream",
+      "file-types": [
+        "st"
+      ],
+      "injection-regex": "^starstream$",
+      "class-name": "TreeSitterStarstream"
+    }
+  ],
+  "metadata": {
+    "version": "0.1.0",
+    "license": "MIT",
+    "description": "Tree Sitter grammar for Starstream",
+    "authors": [
+      {
+        "name": "enzo@dcspark.io"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/PaimaStudios/Starstream"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": false,
+    "node": true,
+    "python": false,
+    "rust": true,
+    "swift": false,
+    "zig": false
+  }
+}


### PR DESCRIPTION
We don't necessarily need to merge this now since it may be annoying to keep the grammar in sync while the language evolves (and in particular until we have codegen writing in the dsl is not that useful anyway). 

I mainly did set this up because I wanted syntax highlighting in helix when working with the examples. It may be useful if someone wants to re-use it for neovim/zed/emacs. Maybe it can be used in the sandbox too, although that'll probably require more work.