### PR TITLE
add .gitattributes excluding starlark from github's linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.star -linguist-detectable


### PR DESCRIPTION
Not a priority by any means, but I think it would be nice if we can get github to not put starlark in the list of languages used:

![image](https://github.com/user-attachments/assets/ebb8f991-2849-43c7-ba9f-8b790438c1b4)

I haven't actually tested this, but it's based on this documentation: https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#detectable