### PR TITLE
utxo abi (methods) codegen

### DIFF
--- a/grammar/examples/oracle.star
+++ b/grammar/examples/oracle.star
@@ -24,12 +24,12 @@ utxo OracleContract {
   }
 
   main(data: Data) {
-    self.data = data;
+    storage.data = data;
     loop { yield; }
   }
 
   impl Oracle {
-    fn get_data(self): Data / { StarstreamEnv } {
+    fn get_data(): Data / { StarstreamEnv } {
       let caller = raise StarstreamEnv::Caller();
       let this_contract = raise StarstreamEnv::ThisCode();
 
@@ -39,7 +39,7 @@ utxo OracleContract {
         raise Oracle::Error("InvalidContext");
       }
 
-      return self.data; // note: this non-mutable, so it's just a reference input
+      return storage.data; // note: this non-mutable, so it's just a reference input
     }
   }
 }

--- a/grammar/examples/pay_to_public_key_hash.star
+++ b/grammar/examples/pay_to_public_key_hash.star
@@ -1,13 +1,32 @@
+abi HasOwner {
+  fn get_owner(): PublicKey;
+}
+
 utxo PayToPublicKeyHash {
+  storage {
+    owner: PublicKey;
+  }
+
   main(owner: PublicKey) {
+    storage.owner = owner;
+
     yield;
     assert(IsTxSignedBy(owner));
+  }
+
+  impl HasOwner {
+    fn get_owner(): PublicKey {
+      storage.owner
+    }
   }
 }
 
 script {
   fn main() / { StarstreamEnv, Starstream } {
-    let input = PayToPublicKeyHash::new(1);
+    let input = PayToPublicKeyHash::new(10);
+
+    let owner = input.get_owner();
+
     input.resume(());
   }
 }

--- a/grammar/examples/permissioned_usdc.star
+++ b/grammar/examples/permissioned_usdc.star
@@ -18,12 +18,12 @@ utxo LinkedListNode {
   }
 
   impl LinkedListNodeAbi {
-    fn get_key(self): PublicKey {
-      self.key
+    fn get_key(): PublicKey {
+      storage.key
     }
 
-    fn get_next(self): PublicKey {
-      self.next
+    fn get_next(): PublicKey {
+      storage.next
     }
   }
 }
@@ -165,7 +165,7 @@ token PermissionedUSDC {
 
     TokenStorage {
       id: PERMISSIONED_TOKEN_ID,
-      amount: self.amount,
+      amount: storage.amount,
     }
   }
 

--- a/starstream_compiler/src/codegen.rs
+++ b/starstream_compiler/src/codegen.rs
@@ -102,7 +102,7 @@ impl StaticType {
             ComparableType::Primitive(PrimitiveType::Bool) => StaticType::Bool,
             ComparableType::Intermediate => StaticType::I64,
             ComparableType::FnType(_, _) => todo!(),
-            ComparableType::Utxo(_symbol_id) => StaticType::I64,
+            ComparableType::Utxo(_symbol_id, _) => StaticType::I64,
             ComparableType::Var(_type_var) => {
                 unreachable!("unbound type variable at the codegen phase")
             }

--- a/starstream_compiler/src/codegen.rs
+++ b/starstream_compiler/src/codegen.rs
@@ -4,14 +4,14 @@ use std::{cmp::Ordering, collections::HashMap, ops::Range, rc::Rc};
 use ariadne::{Report, ReportBuilder, ReportKind};
 use wasm_encoder::{
     BlockType, CodeSection, ConstExpr, DataSection, Encode, EntityType, ExportSection, FuncType,
-    FunctionSection, ImportSection, InstructionSink, MemorySection, MemoryType, Module, RefType,
-    TypeSection, ValType,
+    FunctionSection, ImportSection, InstructionSink, MemArg, MemorySection, MemoryType, Module,
+    RefType, TypeSection, ValType,
 };
 
 use crate::{
     ast::*,
-    symbols::{SymbolId, Symbols},
-    typechecking::{ComparableType, PrimitiveType},
+    symbols::{FuncInfo, SymbolId, SymbolInformation, Symbols, VarInfo},
+    typechecking::{ComparableType, PrimitiveType, TypeVar},
 };
 
 /// Compile a Starstream AST to a binary WebAssembly module.
@@ -58,13 +58,18 @@ enum StaticType {
     // Tuple(Vec<StaticType>),
 
     // User-defined types
-    // Record(Record),
+    Record(Record),
     // Variant(Variant),
     // Enum(Enum),
     Resource(Rc<ResourceType>),
 
     //
     Function(Rc<StarFunctionType>),
+}
+
+#[derive(Debug, Clone)]
+pub struct Record {
+    offsets: HashMap<String, (usize, Box<StaticType>)>,
 }
 
 impl StaticType {
@@ -82,6 +87,7 @@ impl StaticType {
             StaticType::Resource(_) => Intermediate::StackExternRef,
 
             StaticType::Reference(_) => Intermediate::StackI64,
+            s @ StaticType::Record(_) => Intermediate::StackPtr(s.clone()),
             _ => todo!(),
         }
     }
@@ -90,7 +96,10 @@ impl StaticType {
         self.stack_intermediate().stack_types()
     }
 
-    fn from_canonical_type(ty: &ComparableType) -> Self {
+    fn from_canonical_type(
+        ty: &ComparableType,
+        type_vars: &HashMap<TypeVar, ComparableType>,
+    ) -> Self {
         match ty {
             ComparableType::Primitive(PrimitiveType::Unit) => StaticType::Void,
             ComparableType::Primitive(PrimitiveType::U32) => StaticType::U32,
@@ -100,17 +109,49 @@ impl StaticType {
             ComparableType::Primitive(PrimitiveType::F32) => StaticType::F32,
             ComparableType::Primitive(PrimitiveType::F64) => StaticType::F64,
             ComparableType::Primitive(PrimitiveType::Bool) => StaticType::Bool,
-            ComparableType::Intermediate => StaticType::I64,
+            ComparableType::Intermediate => StaticType::I32,
             ComparableType::FnType(_, _) => todo!(),
             ComparableType::Utxo(_symbol_id, _) => StaticType::I64,
-            ComparableType::Var(_type_var) => {
-                unreachable!("unbound type variable at the codegen phase")
+            ComparableType::Var(type_var) => {
+                StaticType::from_canonical_type(type_vars.get(type_var).unwrap(), type_vars)
             }
             ComparableType::Ref(ty) => {
-                StaticType::Reference(Box::new(StaticType::from_canonical_type(ty)))
+                StaticType::Reference(Box::new(StaticType::from_canonical_type(ty, type_vars)))
             }
             ComparableType::Void => StaticType::Void,
+            // represent product types as pointers to linear memory
+            ComparableType::Product(pairs) => {
+                let mut offsets = HashMap::new();
+                let mut offset = 0usize;
+                for (name, ty) in pairs {
+                    let ty = StaticType::from_canonical_type(ty, type_vars);
+                    let ty_mem_size = ty.mem_size();
+                    offsets.insert(name.clone(), (offset, Box::new(ty)));
+
+                    offset += ty_mem_size;
+                }
+
+                StaticType::Record(Record { offsets })
+            }
             _ => todo!(),
+        }
+    }
+
+    fn mem_size(&self) -> usize {
+        match self {
+            StaticType::Void => 0,
+            StaticType::Bool => 1,
+            StaticType::I32 => 4,
+            StaticType::I64 => 8,
+            StaticType::U32 => 4,
+            StaticType::U64 => 8,
+            StaticType::F32 => 4,
+            StaticType::F64 => 8,
+            StaticType::StrRef => 4,
+            StaticType::Reference(_static_type) => 4,
+            StaticType::Record(_record) => 4,
+            StaticType::Resource(_resource_type) => todo!(),
+            StaticType::Function(_star_function_type) => todo!(),
         }
     }
 }
@@ -146,6 +187,9 @@ enum Intermediate {
     StackExternRef,
     /// `(i32 i32)` A string reference, pointer and length.
     StackStrRef,
+
+    /// pointer to linear memory
+    StackPtr(StaticType),
 }
 
 impl Intermediate {
@@ -161,6 +205,7 @@ impl Intermediate {
             Intermediate::StackF64 => &[ValType::F64],
             Intermediate::StackStrRef => &[ValType::I32, ValType::I32],
             Intermediate::StackExternRef => &[ValType::EXTERNREF],
+            Intermediate::StackPtr(_) => &[ValType::I32],
             _ => todo!(),
         }
     }
@@ -229,13 +274,13 @@ struct Compiler {
     // Compiler state.
     bump_ptr: u32,
     raw_func_type_cache: HashMap<FuncType, u32>,
-    function_types: Vec<StarFunctionType>,
+    functions_builder: Vec<(StarFunctionType, Option<Function>)>,
 
     global_scope_functions: HashMap<String, u32>,
 
     symbols_table: Symbols,
 
-    current_utxo: Vec<String>,
+    current_utxo: Vec<SymbolId>,
 }
 
 impl Compiler {
@@ -273,42 +318,129 @@ impl Compiler {
         this.exports
             .export("memory", wasm_encoder::ExportKind::Memory, 0);
 
-        for f_info in symbols_table.functions.values_mut() {
+        let mut fns = symbols_table.functions.values_mut().collect::<Vec<_>>();
+
+        fns.sort_by_key(|f| f.source.clone());
+
+        for f_info in fns.iter_mut() {
             if f_info.source == "resume" && f_info.info.mangled_name.is_some() {
                 let index = this.import_function(
                     "starstream_utxo:this",
                     f_info.info.mangled_name.as_ref().unwrap(),
                     StarFunctionType {
-                        params: f_info
-                            .info
-                            .inputs_canonical_ty
-                            .iter()
-                            .map(StaticType::from_canonical_type)
-                            .collect(),
+                        params: vec![
+                            StaticType::I64,
+                            StaticType::Reference(Box::new(StaticType::Void)),
+                        ],
+
                         results: vec![],
                     },
                 );
 
                 f_info.info.index.replace(index);
-            }
-
-            if f_info.source == "new" && f_info.info.mangled_name.is_some() {
+            } else if f_info.source == "new" && f_info.info.mangled_name.is_some() {
                 let index = this.import_function(
                     "starstream_utxo:this",
                     f_info.info.mangled_name.as_ref().unwrap(),
                     StarFunctionType {
                         params: f_info
                             .info
-                            .inputs_canonical_ty
+                            .inputs_ty
                             .iter()
-                            .map(StaticType::from_canonical_type)
+                            .zip(f_info.info.locals.iter().map(|local| {
+                                symbols_table
+                                    .vars
+                                    .get(local)
+                                    .as_ref()
+                                    .unwrap()
+                                    .info
+                                    .ty
+                                    .as_ref()
+                                    .unwrap()
+                            }))
+                            .map(|(_, ty)| {
+                                StaticType::from_canonical_type(ty, &symbols_table.type_vars)
+                            })
                             .collect(),
                         results: f_info
                             .info
                             .output_canonical_ty
                             .as_ref()
-                            .map(|ty| vec![StaticType::from_canonical_type(ty)])
+                            .map(|ty| {
+                                vec![StaticType::from_canonical_type(
+                                    ty,
+                                    &symbols_table.type_vars,
+                                )]
+                            })
                             .unwrap_or(vec![]),
+                    },
+                );
+
+                f_info.info.index.replace(index);
+            } else if f_info
+                .info
+                .mangled_name
+                .as_ref()
+                .map(|name| name.starts_with("starstream_query"))
+                .unwrap_or(false)
+            {
+                let index = this.import_function(
+                    "starstream_utxo:this",
+                    f_info.info.mangled_name.as_ref().unwrap(),
+                    StarFunctionType {
+                        params: std::iter::once(StaticType::I64)
+                            .chain(
+                                f_info
+                                    .info
+                                    .locals
+                                    .iter()
+                                    .map(|local| {
+                                        symbols_table
+                                            .vars
+                                            .get(local)
+                                            .as_ref()
+                                            .unwrap()
+                                            .info
+                                            .ty
+                                            .as_ref()
+                                            .unwrap()
+                                    })
+                                    .map(|ty| {
+                                        StaticType::from_canonical_type(
+                                            ty,
+                                            &symbols_table.type_vars,
+                                        )
+                                    }),
+                            )
+                            .collect(),
+                        results: f_info
+                            .info
+                            .output_canonical_ty
+                            .as_ref()
+                            .map(|ty| {
+                                vec![StaticType::from_canonical_type(
+                                    ty,
+                                    &symbols_table.type_vars,
+                                )]
+                            })
+                            .unwrap_or(vec![]),
+                    },
+                );
+
+                f_info.info.index.replace(index);
+            } else if f_info.source == "bind" && f_info.info.mangled_name.is_some() {
+                // hacky, just to account for the token storage address passed
+                // currently by the scheduler.
+                //
+                // TODO: the way this is handled right now is not consistent
+                // with the other utxo "methods"
+                f_info.info.inputs_ty.insert(0, TypeArg::Unit);
+                let index = this.import_function(
+                    "starstream_token:this",
+                    f_info.info.mangled_name.as_ref().unwrap(),
+                    StarFunctionType {
+                        params: vec![StaticType::I32],
+                        results: vec![StaticType::I64],
                     },
                 );
 
@@ -337,6 +469,28 @@ impl Compiler {
         add_builtin_assert(&mut this);
         add_builtin_is_tx_signed_by(&mut this);
 
+        for f_info in fns {
+            if f_info.info.mangled_name.is_some() && f_info.info.index.is_none() {
+                let (ty, f) = build_func(
+                    f_info,
+                    &symbols_table.type_vars,
+                    &symbols_table.vars,
+                    f_info.info.is_main,
+                    f_info.info.is_utxo_method,
+                );
+
+                let index = this.add_function(ty, f);
+
+                this.exports.export(
+                    f_info.info.mangled_name.as_ref().unwrap(),
+                    wasm_encoder::ExportKind::Func,
+                    index,
+                );
+
+                f_info.info.index.replace(index);
+            }
+        }
+
         Compiler {
             symbols_table,
             ..this
@@ -352,6 +506,14 @@ impl Compiler {
             shared: false,
             page_size_log2: None,
         });
+
+        for (_, code) in &self.functions_builder {
+            if let Some(code) = code {
+                let mut sink = Vec::new();
+                code.encode(&mut sink);
+                self.code.raw(&sink);
+            }
+        }
 
         // TODO: return None if the errors were fatal.
         let module = self.to_module();
@@ -431,21 +593,18 @@ impl Compiler {
         }
     }
 
-    fn add_function(&mut self, ty: StarFunctionType, code: &Function) -> u32 {
+    fn add_function(&mut self, ty: StarFunctionType, code: Function) -> u32 {
         let type_index = self.add_raw_func_type(ty.lower());
-        let func_index = u32::try_from(self.function_types.len()).unwrap();
-        self.function_types.push(ty);
+        let func_index = u32::try_from(self.functions_builder.len()).unwrap();
+        self.functions_builder.push((ty, Some(code)));
         self.functions.function(type_index);
-        let mut sink = Vec::new();
-        code.encode(&mut sink);
-        self.code.raw(&sink);
         func_index
     }
 
     fn import_function(&mut self, module: &str, field: &str, ty: StarFunctionType) -> u32 {
         let type_index = self.add_raw_func_type(ty.lower());
-        let func_index = u32::try_from(self.function_types.len()).unwrap();
-        self.function_types.push(ty);
+        let func_index = u32::try_from(self.functions_builder.len()).unwrap();
+        self.functions_builder.push((ty, None));
         self.imports
             .import(module, field, EntityType::Function(type_index));
         func_index
@@ -464,23 +623,37 @@ impl Compiler {
         match item {
             ProgramItem::Script(script) => self.visit_script(script),
             ProgramItem::Utxo(utxo) => self.visit_utxo(utxo),
+            ProgramItem::Token(token) => self.visit_token(token),
+            ProgramItem::Abi(_abi) => {}
             _ => self.todo(format!("ProgramItem::{:?}", item)),
         }
     }
 
     fn visit_utxo(&mut self, utxo: &Utxo) {
-        self.current_utxo.push(utxo.name.raw.clone());
+        self.current_utxo.push(utxo.name.uid.unwrap());
 
         for item in &utxo.items {
             match item {
                 UtxoItem::Main(main) => {
-                    let (ty, mut function) = self.build_func(&main.ident.uid.unwrap(), true);
+                    let f_info = self
+                        .symbols_table
+                        .functions
+                        .get(&main.ident.uid.unwrap())
+                        .unwrap();
+
+                    let (ty, mut function) = build_func(
+                        f_info,
+                        &self.symbols_table.type_vars,
+                        &self.symbols_table.vars,
+                        true,
+                        false,
+                    );
 
                     let return_value = self.visit_block(&mut function, &main.block);
                     self.drop_intermediate(&mut function, return_value);
                     function.instructions().end();
 
-                    let index = self.add_function(ty, &function);
+                    let index = self.add_function(ty, function);
 
                     self.exports.export(
                         self.symbols_table.functions[&main.ident.uid.unwrap()]
@@ -492,10 +665,87 @@ impl Compiler {
                         index,
                     );
                 }
-                UtxoItem::Impl(_) => self.todo("utxo methods".to_string()),
-                UtxoItem::Storage(_storage) => self.todo("utxo storage".to_string()),
-                UtxoItem::Yield(_type_arg) => self.todo("yielding data".to_string()),
+                UtxoItem::Impl(utxo_impl) => self.visit_utxo_impl(utxo_impl),
+                UtxoItem::Storage(_storage) => {}
+                UtxoItem::Yield(_type_arg) => {}
                 UtxoItem::Resume(_type_arg) => self.todo("resuming utxo with data".to_string()),
+            }
+        }
+
+        self.current_utxo.pop();
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.current_utxo.push(token.name.uid.unwrap());
+
+        for item in &token.items {
+            match item {
+                TokenItem::Mint(mint) => {
+                    let f_info = self
+                        .symbols_table
+                        .functions
+                        .get(&mint.1.uid.unwrap())
+                        .unwrap();
+
+                    let index = f_info.info.index.unwrap();
+                    let mut function = self.get_function_body(index);
+
+                    let return_value = self.visit_block(&mut function, &mint.0);
+
+                    self.drop_intermediate(&mut function, return_value);
+
+                    function.instructions().local_get(1).end();
+
+                    self.replace_function_body(index, function);
+
+                    let func_info = self
+                        .symbols_table
+                        .functions
+                        .get_mut(&mint.1.uid.unwrap())
+                        .unwrap();
+
+                    func_info.info.index.replace(index);
+                }
+                TokenItem::Bind(bind) => {
+                    let f_info = self
+                        .symbols_table
+                        .functions
+                        .get(&bind.1.uid.unwrap())
+                        .unwrap();
+
+                    let (ty, mut function) = build_func(
+                        f_info,
+                        &self.symbols_table.type_vars,
+                        &self.symbols_table.vars,
+                        f_info.info.is_main,
+                        f_info.info.is_utxo_method,
+                    );
+
+                    let return_value = self.visit_block(&mut function, &bind.0);
+
+                    self.drop_intermediate(&mut function, return_value);
+
+                    function.instructions().end();
+
+                    let index = self.add_function(ty, function);
+
+                    // TODO: probably can avoid this lookup
+                    let name = self
+                        .symbols_table
+                        .functions
+                        .get(&bind.1.uid.unwrap())
+                        .unwrap()
+                        .info
+                        .mangled_name
+                        .clone()
+                        .unwrap();
+
+                    self.exports
+                        .export(&name, wasm_encoder::ExportKind::Func, index);
+                }
+                TokenItem::Unbind(_unbind) => {
+                    // TODO
+                }
             }
         }
 
@@ -504,52 +754,22 @@ impl Compiler {
 
     fn visit_script(&mut self, script: &Script) {
         for fndef in &script.definitions {
-            let (ty, mut function) = self.build_func(&fndef.ident.uid.unwrap(), false);
+            let f_info = self
+                .symbols_table
+                .functions
+                .get(&fndef.ident.uid.unwrap())
+                .unwrap();
+
+            let index = f_info.info.index.unwrap();
+            let mut function = self.get_function_body(index);
 
             let return_value = self.visit_block(&mut function, &fndef.body);
             // TODO: handle non-void return values
             self.drop_intermediate(&mut function, return_value);
             function.instructions().end();
-            let index = self.add_function(ty, &function);
-            self.exports
-                .export(&fndef.ident.raw, wasm_encoder::ExportKind::Func, index);
+
+            self.replace_function_body(index, function);
         }
-    }
-
-    fn build_func(&self, fn_id: &SymbolId, is_main: bool) -> (StarFunctionType, Function) {
-        let f_info = self.symbols_table.functions.get(fn_id).unwrap();
-
-        // TODO: duplicated code
-        let ty = StarFunctionType {
-            params: f_info
-                .info
-                .inputs_canonical_ty
-                .iter()
-                .map(StaticType::from_canonical_type)
-                .collect(),
-            results: if is_main {
-                vec![]
-            } else {
-                f_info
-                    .info
-                    .output_canonical_ty
-                    .as_ref()
-                    .map(|ty| vec![StaticType::from_canonical_type(ty)])
-                    .unwrap_or_default()
-            },
-        };
-        let lower_ty = ty.lower();
-        let mut function = Function::new(lower_ty.params());
-
-        for local in &f_info.info.locals {
-            let var_info = self.symbols_table.vars.get(local).unwrap();
-
-            let val_type =
-                StaticType::from_canonical_type(var_info.info.ty.as_ref().unwrap()).lower()[0];
-
-            function.add_local(val_type);
-        }
-        (ty, function)
     }
 
     fn visit_block(&mut self, func: &mut Function, mut block: &Block) -> Intermediate {
@@ -613,7 +833,13 @@ impl Compiler {
 
                 let var_info = self.symbols_table.vars.get(&var.uid.unwrap()).unwrap();
 
-                func.instructions().local_set(var_info.info.index as u32);
+                func.instructions()
+                    .local_set(var_info.info.index.unwrap() as u32);
+            }
+            Statement::Assign { var, expr } => {
+                let im = self.visit_field_access_expr(func, var, Some(expr));
+
+                assert!(matches!(im, Intermediate::Void));
             }
             _ => self.todo(format!("Statement::{:?}", statement)),
         }
@@ -621,7 +847,7 @@ impl Compiler {
 
     fn visit_expr(&mut self, func: &mut Function, expr: &Spanned<Expr>) -> Intermediate {
         match &expr.node {
-            Expr::PrimaryExpr(secondary) => self.visit_field_access_expr(func, secondary),
+            Expr::PrimaryExpr(secondary) => self.visit_field_access_expr(func, secondary, None),
             Expr::Equals(lhs, rhs) => {
                 let lhs = self.visit_expr(func, lhs);
                 let rhs = self.visit_expr(func, rhs);
@@ -782,11 +1008,13 @@ impl Compiler {
         &mut self,
         func: &mut Function,
         expr: &FieldAccessExpression,
+        // if we have something like x.foo = rhs;
+        rhs: Option<&Spanned<Expr>>,
     ) -> Intermediate {
         match expr {
             FieldAccessExpression::PrimaryExpr(primary) => self.visit_primary_expr(func, primary),
             FieldAccessExpression::FieldAccess { base, field } => {
-                let receiver = self.visit_field_access_expr(func, base);
+                let receiver = self.visit_field_access_expr(func, base, rhs);
 
                 let expr: &IdentifierExpr = field;
                 if let Intermediate::Error = receiver {
@@ -807,9 +1035,71 @@ impl Compiler {
 
                     self.visit_call(func, func_im, xs, Some(receiver))
                 } else {
-                    _ = func;
-                    self.todo(format!("Field {:?}.{:?}", receiver, expr));
-                    Intermediate::Error
+                    let rhs = rhs.map(|expr| self.visit_expr(func, expr));
+
+                    match &receiver {
+                        Intermediate::StackPtr(StaticType::Record(record)) => {
+                            let (offset, ty) = record.offsets.get(&expr.name.raw).unwrap();
+                            let field_offset = MemArg {
+                                offset: *offset as u64,
+                                // TODO:
+                                align: 0,
+                                memory_index: 0,
+                            };
+
+                            if let Some(actual_ty) = rhs.as_ref() {
+                                match (actual_ty, &**ty) {
+                                    (Intermediate::Void, StaticType::Void) => {}
+                                    (Intermediate::StackU64, StaticType::U64) => {}
+                                    (Intermediate::StackI32, StaticType::I32) => {}
+                                    (Intermediate::StackU32, StaticType::U32) => {}
+                                    (expected, found) => {
+                                        Report::build(ReportKind::Error, 0..0)
+                                    .with_message(format_args!(
+                                        "parameter type mismatch: expected {expected:?}, got {found:?}"
+                                    ))
+                                    .push(self);
+                                        return Intermediate::Error;
+                                    }
+                                }
+                            }
+
+                            match &**ty {
+                                StaticType::I32 | StaticType::U32 => {
+                                    if let Some(Intermediate::StackI32 | Intermediate::StackU32) =
+                                        rhs
+                                    {
+                                        func.instructions().i32_store(field_offset);
+                                        Intermediate::Void
+                                    } else {
+                                        func.instructions().i32_load(field_offset);
+                                        Intermediate::StackI32
+                                    }
+                                }
+                                StaticType::I64 | StaticType::U64 => {
+                                    if let Some(Intermediate::StackI64 | Intermediate::StackU64) =
+                                        rhs
+                                    {
+                                        func.instructions().i64_store(field_offset);
+                                        Intermediate::Void
+                                    } else {
+                                        func.instructions().i64_load(field_offset);
+                                        Intermediate::StackI64
+                                    }
+                                }
+                                ty => {
+                                    self.todo(format!("record field access of ty {:?}", ty));
+
+                                    Intermediate::Error
+                                }
+                            }
+                        }
+                        _ => {
+                            _ = func;
+                            self.todo(format!("Field {:?}.{:?}", receiver, expr));
+                            Intermediate::Error
+                        }
+                    }
                 }
             }
         }
@@ -817,9 +1107,32 @@ impl Compiler {
 
     fn visit_primary_expr(&mut self, func: &mut Function, primary: &PrimaryExpr) -> Intermediate {
         match primary {
-            PrimaryExpr::Number(number) => {
-                func.instructions().i32_const(*number as i32);
-                Intermediate::StackI32
+            PrimaryExpr::Number { literal, ty } => {
+                match StaticType::from_canonical_type(
+                    ty.as_ref().unwrap(),
+                    &self.symbols_table.type_vars,
+                ) {
+                    StaticType::I32 => {
+                        func.instructions().i32_const(*literal as i32);
+                        Intermediate::StackI32
+                    }
+                    StaticType::I64 => {
+                        func.instructions().i64_const(*literal as i64);
+                        Intermediate::StackI64
+                    }
+                    StaticType::U32 => {
+                        func.instructions().i32_const(*literal as i32);
+                        Intermediate::StackU32
+                    }
+                    StaticType::U64 => {
+                        func.instructions().i64_const(*literal as i64);
+                        Intermediate::StackU64
+                    }
+                    ty => {
+                        self.todo(format!("numeric literal of ty {:?}", ty));
+                        Intermediate::Error
+                    }
+                }
             }
             PrimaryExpr::Bool(true) => {
                 func.instructions().i32_const(1);
@@ -843,9 +1156,15 @@ impl Compiler {
 
                     let ty = var_info.info.ty.as_ref().unwrap();
 
-                    func.instructions().local_get(var_info.info.index as u32);
+                    if var_info.info.is_storage.is_some() {
+                        func.instructions().i32_const(0);
+                    } else {
+                        func.instructions()
+                            .local_get(var_info.info.index.unwrap() as u32);
+                    }
 
-                    return StaticType::from_canonical_type(ty).stack_intermediate();
+                    return StaticType::from_canonical_type(ty, &self.symbols_table.type_vars)
+                        .stack_intermediate();
                 }
 
                 let im = if ident.name.raw == "print" {
@@ -883,38 +1202,62 @@ impl Compiler {
                     .i32_const(u32::try_from(len).unwrap().cast_signed());
                 Intermediate::StackStrRef
             }
-            PrimaryExpr::Yield(_expr) => {
-                let f_id = self.global_scope_functions["starstream_yield"];
-
-                // TODO: yielding outside utxos
-                let utxo_name = self.current_utxo.pop().unwrap();
-                let ptr = self.alloc_constant(utxo_name.as_bytes());
-                let len = utxo_name.len();
-                func.instructions()
-                    .i32_const(ptr.cast_signed())
-                    .i32_const(u32::try_from(len).unwrap().cast_signed());
-
-                // TODO: yield data
-
-                // data
-                func.instructions().i32_const(0);
-                // data_len
-                func.instructions().i32_const(0);
-                // resume_arg
-                func.instructions().i32_const(0);
-                // resume_arg_len
-                func.instructions().i32_const(0);
-
-                func.instructions().call(f_id);
-
-                Intermediate::Void
-            }
+            PrimaryExpr::Yield(expr) => self.visit_yield(func, expr),
             PrimaryExpr::Tuple(elems) if elems.is_empty() => Intermediate::Void,
             _ => {
                 self.todo(format!("PrimaryExpr::{:?}", primary));
                 Intermediate::Error
             }
         }
+    }
+
+    fn visit_yield(
+        &mut self,
+        func: &mut Function,
+        expr: &Option<Box<Spanned<Expr>>>,
+    ) -> Intermediate {
+        let f_id = self.global_scope_functions["starstream_yield"];
+
+        // TODO: yielding outside utxos
+        let utxo_id = self.current_utxo.last().unwrap();
+
+        let utxo_info = self.symbols_table.types.get(utxo_id).unwrap();
+
+        let utxo_name = utxo_info.source.clone();
+        let ptr = self.alloc_constant(utxo_name.as_bytes());
+        let len = utxo_name.len();
+
+        // TODO: yield data but the thing is that coordination scripts are a
+        // bit different from utxos in this regard so we may want to do some
+        // transformations first, or split into two cases here.
+        let _im = if let Some(expr) = expr {
+            // address
+            //
+            // assume that the utxo storage is always at address 0, which is sound since
+            // the utxo has its own memory space anyway.
+            func.instructions().i32_const(0);
+
+            self.visit_expr(func, expr)
+        } else {
+            Intermediate::Void
+        };
+
+        func.instructions()
+            .i32_const(ptr.cast_signed())
+            .i32_const(u32::try_from(len).unwrap().cast_signed());
+
+        // data
+        func.instructions().i32_const(0);
+        // data_len
+        func.instructions().i32_const(0);
+        // resume_arg
+        func.instructions().i32_const(0);
+        // resume_arg_len
+        func.instructions().i32_const(0);
+
+        func.instructions().call(f_id);
+
+        Intermediate::Void
     }
 
     fn visit_call(
@@ -927,7 +1270,8 @@ impl Compiler {
         match im {
             Intermediate::Error => Intermediate::Error,
             Intermediate::ConstFunction(id) => {
-                let func_type = self.function_types[id as usize].clone();
+                let func_type = self.functions_builder[id as usize].0.clone();
+
                 for (param, arg) in func_type
                     .params
                     .iter()
@@ -966,7 +1310,7 @@ impl Compiler {
                 match func_type
                     .params
                     .len()
-                    .cmp(&(args.len() + method_self.map(|_| 1).unwrap_or(0)))
+                    .cmp(&(args.len() + if method_self.is_some() { 1 } else { 0 }))
                 {
                     Ordering::Equal => {}
                     Ordering::Less => {
@@ -976,7 +1320,7 @@ impl Compiler {
                     }
                     Ordering::Greater => {
                         Report::build(ReportKind::Error, 0..0)
-                            .with_message("not enough arguments to function call")
+                            .with_message("too many arguments to function call")
                             .push(self);
                     }
                 }
@@ -995,6 +1339,58 @@ impl Compiler {
                 Intermediate::Error
             }
         }
+    }
+
+    fn visit_utxo_impl(&mut self, utxo_impl: &Impl) {
+        for fndef in &utxo_impl.definitions {
+            let f_info = self
+                .symbols_table
+                .functions
+                .get(&fndef.ident.uid.unwrap())
+                .unwrap();
+
+            let (ty, mut function) = build_func(
+                f_info,
+                &self.symbols_table.type_vars,
+                &self.symbols_table.vars,
+                false,
+                true,
+            );
+
+            let _return_value = self.visit_block(&mut function, &fndef.body);
+            function.instructions().end();
+
+            let index = self.add_function(ty, function);
+
+            // TODO: probably can avoid this lookup
+            let name = self
+                .symbols_table
+                .functions
+                .get(&fndef.ident.uid.unwrap())
+                .unwrap()
+                .info
+                .mangled_name
+                .clone()
+                .unwrap_or(fndef.ident.raw.clone());
+
+            self.exports
+                .export(&name, wasm_encoder::ExportKind::Func, index);
+        }
+    }
+
+    fn replace_function_body(&mut self, index: u32, function: Function) {
+        self.functions_builder
+            .get_mut(index as usize)
+            .map(|(_, f)| f)
+            .unwrap()
+            .replace(function);
+    }
+
+    fn get_function_body(&mut self, index: u32) -> Function {
+        self.functions_builder
+            .get_mut(index as usize)
+            .map(|(_, f)| f.take().unwrap())
+            .unwrap()
     }
 }
 
@@ -1015,7 +1411,7 @@ fn add_builtin_assert(this: &mut Compiler) {
             params: vec![StaticType::Bool],
             results: vec![],
         },
-        &function,
+        function,
     );
 
     this.global_scope_functions
@@ -1032,7 +1428,7 @@ fn add_builtin_is_tx_signed_by(this: &mut Compiler) {
             params: vec![StaticType::I32],
             results: vec![StaticType::Bool],
         },
-        &function,
+        function,
     );
 
     this.global_scope_functions
@@ -1099,6 +1495,56 @@ impl wasm_encoder::Encode for Function {
         }
         sink.extend_from_slice(&self.bytes);
     }
+}
+
+fn build_func(
+    f_info: &SymbolInformation<FuncInfo>,
+    type_vars: &HashMap<TypeVar, ComparableType>,
+    vars: &HashMap<SymbolId, SymbolInformation<VarInfo>>,
+    is_main: bool,
+    is_utxo_method: bool,
+) -> (StarFunctionType, Function) {
+    // TODO: duplicated code
+    let ty = StarFunctionType {
+        params: f_info
+            .info
+            .inputs_ty
+            .iter()
+            .zip(
+                std::iter::once(&ComparableType::Product(vec![]))
+                    .filter(|_| is_utxo_method)
+                    .chain(f_info.info.locals.iter().map(|local| {
+                        let var_info = &vars.get(local).as_ref().unwrap().info;
+
+                        var_info.ty.as_ref().unwrap()
+                    })),
+            )
+            .map(|(_, ty)| StaticType::from_canonical_type(ty, type_vars))
+            .collect(),
+        results: if is_main {
+            vec![]
+        } else {
+            f_info
+                .info
+                .output_canonical_ty
+                .as_ref()
+                .map(|ty| vec![StaticType::from_canonical_type(ty, type_vars)])
+                .unwrap_or_default()
+        },
+    };
+    let lower_ty = ty.lower();
+    let mut function = Function::new(lower_ty.params());
+
+    for local in &f_info.info.locals {
+        let var_info = vars.get(local).unwrap();
+
+        let val_type =
+            StaticType::from_canonical_type(var_info.info.ty.as_ref().unwrap(), type_vars).lower()
+                [0];
+
+        function.add_local(val_type);
+    }
+    (ty, function)
 }
 
 // -----------------------------------------------------------------------------

--- a/starstream_compiler/src/symbols.rs
+++ b/starstream_compiler/src/symbols.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::{Sig, Storage, TypeArg, TypeDefRhs},
-    typechecking::{ComparableType, EffectSet},
+    typechecking::{ComparableType, EffectSet, TypeVar},
 };
 use chumsky::span::SimpleSpan;
 use std::collections::{HashMap, HashSet};
@@ -16,19 +16,24 @@ pub struct Symbols {
     // lookup for builtin types inside the `types`, since these don't have
     // identifiers on the ast
     pub builtins: HashMap<&'static str, SymbolId>,
+
+    // stores unification results after type inference
+    pub type_vars: HashMap<TypeVar, ComparableType>,
 }
 
 #[derive(Debug, Clone)]
 pub struct VarInfo {
-    pub index: u64,
+    pub index: Option<u64>,
     pub mutable: bool,
     pub ty: Option<ComparableType>,
+    pub is_storage: Option<SymbolId>,
 }
 
 #[derive(Debug, Clone)]
 pub struct TypeInfo {
     pub declarations: HashSet<SymbolId>,
     pub storage: Option<Storage>,
+    pub storage_ty: Option<ComparableType>,
     // TODO: may want to separate typedefs from utxo and token types
     pub type_def: Option<TypeDefRhs>,
     pub yield_ty: Option<TypeArg>,
@@ -41,7 +46,6 @@ pub struct FuncInfo {
     pub inputs_ty: Vec<TypeArg>,
     pub output_ty: Option<TypeArg>,
 
-    pub inputs_canonical_ty: Vec<ComparableType>,
     pub output_canonical_ty: Option<ComparableType>,
 
     pub effects: EffectSet,
@@ -49,6 +53,11 @@ pub struct FuncInfo {
     pub mangled_name: Option<String>,
     // index into the wasm functions table
     pub index: Option<u32>,
+
+    pub storage: Option<SymbolId>,
+
+    pub is_main: bool,
+    pub is_utxo_method: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/starstream_compiler/src/typechecking/error.rs
+++ b/starstream_compiler/src/typechecking/error.rs
@@ -37,7 +37,7 @@ pub(super) fn error_type_mismatch(
         .with_code(TypeErrorCode::TypeMismatch as u32)
         .with_label(
             Label::new(span.into_range())
-                .with_message(format!("expected {:?}, found {:?}", expected, found))
+                .with_message(format!("expected {}, found {}", expected, found))
                 .with_color(Color::Red),
         )
         .finish()

--- a/starstream_compiler/src/typechecking/types.rs
+++ b/starstream_compiler/src/typechecking/types.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{TypeArg, TypeDefRhs, TypedBindings},
+    ast::{Storage, TypeArg, TypeDefRhs, TypedBindings},
     symbols::{FuncInfo, SymbolId, SymbolInformation, Symbols, TypeInfo},
 };
 use std::collections::HashMap;
@@ -125,7 +125,10 @@ impl ComparableType {
     }
 
     pub const fn is_affine(&self) -> bool {
-        matches!(self, ComparableType::Utxo(_, _))
+        // matches!(self, ComparableType::Utxo(_, _))
+        // disable this for now for simplicity
+        // we need the syntax/types to properly differentiate the method type
+        false
     }
 
     pub(crate) fn token_storage() -> ComparableType {
@@ -141,6 +144,10 @@ impl ComparableType {
             ty => ty.clone(),
         }
     }
+
+    pub fn from_storage(storage: &Storage, symbols: &Symbols) -> Self {
+        typed_bindings_to_product(&storage.bindings, &symbols.types)
+    }
 }
 
 impl TypeArg {
@@ -154,8 +161,8 @@ impl TypeArg {
             TypeArg::String => ComparableType::Primitive(PrimitiveType::StrRef),
             TypeArg::U32 => ComparableType::Primitive(PrimitiveType::U32),
             TypeArg::I32 => ComparableType::Primitive(PrimitiveType::I32),
-            TypeArg::U64 => ComparableType::Primitive(PrimitiveType::U32),
-            TypeArg::I64 => ComparableType::Primitive(PrimitiveType::U64),
+            TypeArg::U64 => ComparableType::Primitive(PrimitiveType::U64),
+            TypeArg::I64 => ComparableType::Primitive(PrimitiveType::I64),
             TypeArg::F32 => ComparableType::Primitive(PrimitiveType::F32),
             TypeArg::F64 => ComparableType::Primitive(PrimitiveType::F64),
             TypeArg::Intermediate { abi: _, storage: _ } => ComparableType::Intermediate,


### PR DESCRIPTION
Still a draft since this needs some cleanup (there are a few hacks here and there), but this PR adds codegen for the utxo abi functions. So the following example works:

```ts
abi HasOwner {
  fn get_owner(): PublicKey;
}

utxo PayToPublicKeyHash {
  storage {
    owner: PublicKey;
  }

  main(owner: PublicKey) {
    storage.owner = owner;

    yield;
    assert(IsTxSignedBy(owner));
  }

  impl HasOwner {
    fn get_owner(): PublicKey {
      storage.owner
    }
  }
}

script {
  fn main() / { StarstreamEnv, Starstream } {
    let input = PayToPublicKeyHash::new(10);

    let owner = input.get_owner();

    input.resume(());
  }
}
```

I'm still not too sure about the syntax change (self -> storage). The motivation was partially that `storage` can just have the type of the record, and not the type of `self` (which is annoying because `self` is a different thing in the function definition and in the place function is called). I've been thinking that we could just have `fn` and `mut fn` directly instead of borrowing rust's syntax tbh. All of the utxo functions will need access to the storage anyway. (It's a different story with "methods" for other non-utxo types though, but that can't be done yet).

The storage is a record, so this also adds the codegen to assign to fields, and to get fields values (not to allocate a record though). The storage is currently just hardcoded to the memory address `0`. Since utxos have their own address space then this is probably fine. But for effect handlers in scripts the same approach won't work, so it may be worth having both be consistent. 

Also this PR implements some support for binding tokens, for example:

```ts
abi HasTokens {
  fn attach_token(Intermediate<any, any>): Token;
}


utxo PayToPublicKeyHash {
  main(owner: PublicKey) {
    yield;
    assert(IsTxSignedBy(owner));
  }

  impl HasTokens {
    fn attach_token(intermediate: Intermediate<any, any>): Token / { StarstreamEnv } {
      Token::bind(intermediate)
    }
  }
}

script {
  fn main() / { StarstreamEnv, Starstream } {
    let input = PayToPublicKeyHash::new(10);

    let intermediate = Token::mint(13);

    input.attach_token(intermediate);

    input.resume(());
  }
}

token Token {}
```

Although I did this partially for testing a few things, and not because it was the focus of the PR. I think the next step is most likely the effect handlers (which should work similarly to the utxo methods). But maybe we could write a simplified version of the oracle example with just tokens and without effect handlers, to at least have a working version on the sandbox.

## TODO

I disabled the affine constraint on the utxo for the examples to work. Since the checker currently just counts uses of the variable. To fix this, either we need to check not only that the variable is used, but in which kind of function. Or every utxo abi function will have to return a tuple (which is a bit annoying since we don't have de-structuring, but possible).