### PR TITLE
Refactor token abi + corresponding codegen/test

### DIFF
--- a/grammar/examples/effect_handlers.star
+++ b/grammar/examples/effect_handlers.star
@@ -33,7 +33,7 @@ utxo Utxo {
 }
 
 script {
-  fn main() / { StarstreamEnv, Starstream } {
+  fn main() / { StarstreamEnv } {
     let x = 5;
     try {
       let utxo = Utxo::new();

--- a/grammar/examples/oracle.star
+++ b/grammar/examples/oracle.star
@@ -1,5 +1,3 @@
-const FeeToken = 3;
-
 typedef Data = string
 
 const ORACLE_FEE = 10;
@@ -44,6 +42,8 @@ utxo OracleContract {
   }
 }
 
+token FeeToken {}
+
 script {
   fn get_oracle_data(input: PayToPublicKeyHash, oracle: OracleContract): Data / { StarstreamEnv, Oracle } {
     let change_utxo = PayToPublicKeyHash::new(raise StarstreamEnv::Caller());
@@ -53,11 +53,11 @@ script {
     try {
       input.resume();
     }
-    with Starstream::TokenUnbound(intermediate: Intermediate<any, any>, type: u32) {
-      if(type == FeeToken) {
-        let intermediates = intermediate.change_for(ORACLE_FEE);
-        change_utxo.attach(intermediates.fst);
-        fee_utxo.attach(intermediates.snd);
+    with StarstreamToken::TokenUnbound(intermediate: Intermediate<any, any>) {
+      if(intermediate.type() == FeeToken::id()) {
+        let fee = intermediate.spend(10);
+        change_utxo.attach(intermediate);
+        fee_utxo.attach(fee);
       }
       else {
         change_utxo.attach(intermediate);

--- a/grammar/examples/pay_to_public_key_hash.star
+++ b/grammar/examples/pay_to_public_key_hash.star
@@ -6,7 +6,7 @@ utxo PayToPublicKeyHash {
 }
 
 script {
-  fn main() / { StarstreamEnv, Starstream } {
+  fn main() / { StarstreamEnv } {
     let input = PayToPublicKeyHash::new(1);
     input.resume(());
   }

--- a/grammar/examples/permissioned_usdc.star
+++ b/grammar/examples/permissioned_usdc.star
@@ -58,8 +58,8 @@ script {
     try {
       source.next();
     }
-    with Starstream::TokenUnbound(token: Intermediate<any, any>) {
-      if(token.type == PermissionedUSDC::type()) {
+    with StarstreamToken::TokenUnbound(token: Intermediate<any, any>) {
+      if(token.type == PermissionedUSDC::id()) {
         input_amount = input_amount + token.amount;
       }
       else {

--- a/grammar/examples/simple_oracle.star
+++ b/grammar/examples/simple_oracle.star
@@ -8,6 +8,24 @@ abi SimpleOracleAbi {
   fn get_data(Intermediate<any, any>): Data;
 }
 
+abi HasTokens {
+  fn attach_token(Intermediate<any, any>);
+}
+
+utxo PayToPublicKeyHash {
+  main(owner: PublicKey) {
+    yield;
+    assert(IsTxSignedBy(owner));
+  }
+
+  impl HasTokens {
+    fn attach_token(intermediate: Intermediate<any, any>) / { StarstreamEnv } {
+      // PayToPublicKeyHash accepts any token
+      intermediate.bind();
+    }
+  }
+}
+
 utxo SimpleOracle {
   storage {
     owner: u32;
@@ -16,15 +34,20 @@ utxo SimpleOracle {
 
   main(owner: PublicKey) {
     storage.owner = owner;
-    storage.data = 111;
+    storage.data = 42;
 
     yield;
+    // only the owner of the oracle can resume it
     assert(IsTxSignedBy(owner));
   }
 
   impl SimpleOracleAbi {
     fn get_data(intermediate: Intermediate<any, any>): Data / { StarstreamEnv } {
-      Token::bind(intermediate);
+      assert(intermediate.type() == OracleToken::id());
+      assert(intermediate.amount() == 1);
+
+      // take the token as payment
+      intermediate.bind();
 
       storage.data
     }
@@ -38,19 +61,37 @@ utxo SimpleOracle {
 }
 
 script {
-  fn main() / { StarstreamEnv } {
-    let oracle = SimpleOracle::new(1);
+  fn main(): PayToPublicKeyHash / { StarstreamEnv } {
+    // the PublicKey for the change
+    let caller = 45000;
 
-    let token_intermediate = Token::mint(1);
-    let data = oracle.get_data(token_intermediate);
+    // these would be inputs to the tx
+    let mint_amount = 10;
+    let input = OracleToken::mint(mint_amount);
+
+    let oracle = SimpleOracle::new(113);
+
+    // leaves a value of 9 in the input token
+    // and this new token has a value of 1
+    let fee_payment = input.spend(1);
+
+    let data = oracle.get_data(fee_payment);
+
+    let change = PayToPublicKeyHash::new(caller);
+
+    // balance the transaction
+
+    // change has to be either attached or burned
+    // otherwise we get an error (tokens are linear types)
+    change.attach_token(input);
+
+    change
   }
+
 }
 
-token Token {
+token OracleToken {
   mint {
-    assert(amount == 1);
-    // some public key or permission for the admin
-    // although the actual permissions should be in bind
     assert(IsTxSignedBy(110));
   }
 }

--- a/grammar/examples/simple_oracle.star
+++ b/grammar/examples/simple_oracle.star
@@ -38,7 +38,7 @@ utxo SimpleOracle {
 }
 
 script {
-  fn main() / { StarstreamEnv, Starstream } {
+  fn main() / { StarstreamEnv } {
     let oracle = SimpleOracle::new(1);
 
     let token_intermediate = Token::mint(1);

--- a/grammar/examples/tokens.star
+++ b/grammar/examples/tokens.star
@@ -1,0 +1,80 @@
+abi HasTokens {
+  fn attach_token(Intermediate<any, any>);
+}
+
+utxo PayToPublicKeyHash {
+  main(owner: u32) {
+    yield;
+    assert(IsTxSignedBy(owner));
+
+    unbind_utxo_tokens();
+  }
+
+  impl StarstreamToken {}
+
+  impl HasTokens {
+    fn attach_token(intermediate: Intermediate<any, any>) / { StarstreamEnv } {
+      intermediate.bind();
+    }
+  }
+}
+
+token Token1 {
+  mint {
+    assert(IsTxSignedBy(0));
+  }
+}
+
+token Token2 {
+  mint {
+    assert(amount == 15);
+    assert(IsTxSignedBy(0));
+  }
+}
+
+script {
+  fn main() / { StarstreamEnv, HasTokens } {
+    try {
+      let output = PayToPublicKeyHash::new(0);
+
+      let utxo1 = PayToPublicKeyHash::new(0);
+      let utxo2 = PayToPublicKeyHash::new(0);
+
+      let utxo_1_token_1 = Token1::mint(10);
+      let utxo_1_token_2 = Token2::mint(15);
+
+      let utxo_2_token_1 = Token1::mint(10);
+
+      utxo1.attach_token(utxo_1_token_1);
+      utxo1.attach_token(utxo_1_token_2);
+
+      utxo2.attach_token(utxo_2_token_1);
+
+      try {
+        utxo1.resume(());
+      }
+      with StarstreamToken::TokenUnbound(i: Intermediate<any, any>) {
+        assert(i.type() == Token1::id() || i.type() == Token2::id());
+
+        let other = i.spend(5);
+
+        output.attach_token(i);
+        output.attach_token(other);
+      }
+
+      try {
+        utxo2.resume(());
+      }
+      with StarstreamToken::TokenUnbound(i: Intermediate<any, any>) {
+        assert(i.type() == Token1::id() && i.amount() == 10);
+
+        i.burn();
+      }
+    }
+    with StarstreamToken::TokenUnbound(i: Intermediate<any, any>) {
+	  // there shouldn't be any unbound tokens before the first yield
+      assert(false);
+      i.burn();
+    }
+  }
+}

--- a/starstream_compiler/src/codegen.rs
+++ b/starstream_compiler/src/codegen.rs
@@ -518,40 +518,8 @@ impl Compiler {
                 );
 
                 f_info.info.index.replace(index);
-            } else if f_info.source == "mint" && f_info.info.mangled_name.is_some() {
-                let index = this.import_function(
-                    "starstream_utxo:this",
-                    f_info.info.mangled_name.as_ref().unwrap(),
-                    StarFunctionType {
-                        params: vec![StaticType::U64],
-                        results: vec![StaticType::I64],
-                    },
-                );
-
-                f_info.info.index.replace(index);
-            } else if f_info.source == "bind"
-                && f_info.info.mangled_name.is_some()
-                && f_info.info.dispatch_through.is_none()
-            {
-                // hacky, just to account for the token storage address passed
-                // currently by the scheduler.
-                //
-                // TODO: the way this is handled right now is not consistent
-                // with the other utxo "methods"
-                f_info.info.inputs_ty.insert(0, TypeArg::Unit);
-                let index = this.import_function(
-                    f_info.info.is_imported.unwrap(),
-                    f_info.info.mangled_name.as_ref().unwrap(),
-                    StarFunctionType {
-                        params: vec![StaticType::I64],
-                        results: vec![],
-                    },
-                );
-
-                f_info.info.index.replace(index);
-            } else if f_info.source == "unbind"
-                && f_info.info.mangled_name.is_some()
-                && f_info.info.dispatch_through.is_none()
+            } else if ["bind", "unbind"].contains(&f_info.source.as_str())
+                && f_info.info.is_imported.is_some()
             {
                 let index = this.import_function(
                     f_info.info.is_imported.unwrap(),
@@ -565,7 +533,7 @@ impl Compiler {
                 f_info.info.index.replace(index);
 
                 this.global_scope_functions
-                    .insert("unbind".to_string(), index);
+                    .insert(f_info.source.clone(), index);
             } else if ["spend", "burn", "amount", "type", "mint"].contains(&f_info.source.as_str())
                 && f_info.info.is_imported.is_some()
             {

--- a/starstream_compiler/src/scope_resolution.rs
+++ b/starstream_compiler/src/scope_resolution.rs
@@ -2,7 +2,6 @@ use crate::error::NameResolutionError;
 use crate::symbols::{
     self, AbiInfo, ConstInfo, FuncInfo, SymbolId, SymbolInformation, Symbols, TypeInfo, VarInfo,
 };
-use crate::typechecking::ComparableType;
 use crate::{
     ast::{
         Abi, AbiElem, Block, BlockExpr, EffectDecl, Expr, ExprOrStatement, FieldAccessExpression,
@@ -764,9 +763,6 @@ impl Visitor {
         let (uid, _) = self
             .resolve_name(&mut token.name, SymbolKind::Type)
             .unwrap();
-
-        let self_ty = TypeArg::TypeRef(TypeRef(token.name.clone()));
-        let self_ty_ref = TypeArg::Ref(Box::new(self_ty.clone()));
 
         self.push_type_scope(uid);
 

--- a/starstream_compiler/src/scope_resolution.rs
+++ b/starstream_compiler/src/scope_resolution.rs
@@ -2,6 +2,7 @@ use crate::error::NameResolutionError;
 use crate::symbols::{
     self, AbiInfo, ConstInfo, FuncInfo, SymbolId, SymbolInformation, Symbols, TypeInfo, VarInfo,
 };
+use crate::typechecking::ComparableType;
 use crate::{
     ast::{
         Abi, AbiElem, Block, BlockExpr, EffectDecl, Expr, ExprOrStatement, FieldAccessExpression,
@@ -62,6 +63,9 @@ struct Visitor {
     symbol_counter: u64,
     errors: Vec<NameResolutionError>,
     symbols: Symbols,
+
+    global_bind_fn: Option<SymbolId>,
+    global_unbind_fn: Option<SymbolId>,
 }
 
 #[derive(Debug, Clone)]
@@ -81,6 +85,8 @@ impl Visitor {
             symbol_counter: 0,
             errors: vec![],
             symbols: Symbols::default(),
+            global_bind_fn: None,
+            global_unbind_fn: None,
         }
     }
 
@@ -175,7 +181,6 @@ impl Visitor {
                 inputs_ty: vec![],
                 output_ty: None,
                 effects: EffectSet::empty(),
-                locals: vec![],
                 ..Default::default()
             },
         );
@@ -186,7 +191,16 @@ impl Visitor {
                 inputs_ty: vec![TypeArg::String],
                 output_ty: None,
                 effects: EffectSet::empty(),
-                locals: vec![],
+                ..Default::default()
+            },
+        );
+
+        self.push_function_declaration(
+            &mut Identifier::new("amount", None),
+            FuncInfo {
+                inputs_ty: vec![],
+                output_ty: None,
+                effects: EffectSet::empty(),
                 ..Default::default()
             },
         );
@@ -197,7 +211,6 @@ impl Visitor {
                 inputs_ty: vec![TypeArg::U32],
                 output_ty: Some(TypeArg::Bool),
                 effects: EffectSet::empty(),
-                locals: vec![],
                 ..Default::default()
             },
         );
@@ -212,24 +225,34 @@ impl Visitor {
         });
 
         let mut abi = Abi {
-            name: Identifier::new("Starstream", None),
+            name: Identifier::new("StarstreamToken", None),
             values: vec![AbiElem::EffectDecl(EffectDecl::EffectSig(Sig {
                 name: Identifier::new("TokenUnbound", None),
-                input_types: vec![
-                    TypeArg::Intermediate {
-                        abi: any.clone(),
-                        storage: any.clone(),
-                    },
-                    TypeArg::U32,
-                ],
+                input_types: vec![TypeArg::Intermediate {
+                    abi: any.clone(),
+                    storage: any.clone(),
+                }],
                 output_type: None,
             }))],
         };
 
-        self.visit_abi(&mut abi, false);
+        self.visit_abi(&mut abi, true);
+
         self.symbols
             .builtins
             .insert(STARSTREAM, abi.name.uid.unwrap());
+
+        self.push_function_declaration(
+            &mut Identifier::new("unbind_utxo_tokens", None),
+            FuncInfo {
+                inputs_ty: vec![],
+                output_ty: None,
+                effects: EffectSet::singleton(abi.name.uid.unwrap()),
+                mangled_name: Some("unbind_utxo_tokens".to_string()),
+                locals: vec![],
+                ..Default::default()
+            },
+        );
 
         let mut abi = Abi {
             name: Identifier::new("StarstreamEnv", None),
@@ -295,9 +318,10 @@ impl Visitor {
 
         let self_ty = TypeArg::Intermediate {
             abi: any.clone(),
-            storage: any,
+            storage: any.clone(),
         };
 
+        // TODO: maybe better to have builtin multi-return support.
         let pair = Identifier::new("IntermediatePair", None);
         let mut type_def = TypeDef {
             name: pair,
@@ -322,6 +346,82 @@ impl Visitor {
                 ..Default::default()
             },
         );
+        let intermediate_ty = TypeArg::Intermediate {
+            abi: any.clone(),
+            storage: any.clone(),
+        };
+
+        self.push_function_declaration(
+            &mut Identifier::new("type", None),
+            FuncInfo {
+                inputs_ty: vec![intermediate_ty.clone()],
+                output_ty: Some(TypeArg::I64),
+                mangled_name: Some("starstream_get_token_type".to_string()),
+                is_imported: Some("env"),
+                ..Default::default()
+            },
+        );
+
+        self.push_function_declaration(
+            &mut Identifier::new("amount", None),
+            FuncInfo {
+                inputs_ty: vec![intermediate_ty.clone()],
+                output_ty: Some(TypeArg::U64),
+                mangled_name: Some("starstream_get_token_amount".to_string()),
+                is_imported: Some("env"),
+                ..Default::default()
+            },
+        );
+
+        self.push_function_declaration(
+            &mut Identifier::new("burn", None),
+            FuncInfo {
+                inputs_ty: vec![intermediate_ty.clone()],
+                mangled_name: Some("starstream_token_burn".to_string()),
+                is_imported: Some("env"),
+                moves_variable: true,
+                ..Default::default()
+            },
+        );
+
+        self.push_function_declaration(
+            &mut Identifier::new("spend", None),
+            FuncInfo {
+                inputs_ty: vec![intermediate_ty.clone(), TypeArg::U64],
+                output_ty: Some(intermediate_ty.clone()),
+                mangled_name: Some("starstream_token_spend".to_string()),
+                is_imported: Some("env"),
+                ..Default::default()
+            },
+        );
+
+        let bind_fn = self.push_function_declaration(
+            &mut Identifier::new("bind", None),
+            FuncInfo {
+                inputs_ty: vec![intermediate_ty.clone()],
+                output_ty: None,
+                mangled_name: Some("starstream_bind".to_string()),
+                is_imported: Some("starstream_token:this"),
+                moves_variable: true,
+                ..Default::default()
+            },
+        );
+
+        // fixme?: maybe just setup this in new to avoid the unwrap
+        self.global_bind_fn.replace(bind_fn);
+
+        let unbind_fn = self.push_function_declaration(
+            &mut Identifier::new("unbind", None),
+            FuncInfo {
+                inputs_ty: vec![intermediate_ty.clone()],
+                output_ty: Some(TypeArg::I64),
+                mangled_name: Some("starstream_unbind".to_string()),
+                is_imported: Some("starstream_token:this"),
+                ..Default::default()
+            },
+        );
+        // fixme?: maybe just setup this in new to avoid the unwrap
+        self.global_unbind_fn.replace(unbind_fn);
 
         self.pop_scope();
     }
@@ -462,6 +562,7 @@ impl Visitor {
                 effects,
                 locals: vec![],
                 mangled_name: Some(format!("starstream_resume_{}", utxo.name.raw)),
+                moves_variable: true,
                 ..Default::default()
             },
         );
@@ -671,23 +772,24 @@ impl Visitor {
 
         let effects = self.implicit_effects();
         self.push_function_declaration(
-            &mut Identifier::new("type", None),
+            &mut Identifier::new("id", None),
             FuncInfo {
                 inputs_ty: vec![],
                 // TODO: something else
-                output_ty: Some(TypeArg::U32),
+                output_ty: Some(TypeArg::I64),
                 effects: effects.clone(),
+                is_constant: Some(uid.id),
                 locals: vec![],
                 ..Default::default()
             },
         );
+        let any = Box::new(TypeArg::TypeRef(TypeRef(Identifier::new("any", None))));
 
         for item in &mut token.items {
             let effects = self.implicit_effects();
 
             match item {
                 TokenItem::Bind(bind) => {
-                    let any = Box::new(TypeArg::TypeRef(TypeRef(Identifier::new("any", None))));
                     self.push_function_declaration(
                         &mut bind.1,
                         FuncInfo {
@@ -695,11 +797,15 @@ impl Visitor {
                                 abi: any.clone(),
                                 storage: any.clone(),
                             }],
-                            output_ty: Some(self_ty_ref.clone()),
+                            output_ty: None,
                             effects,
                             locals: vec![],
                             is_main: true,
-                            mangled_name: Some(format!("starstream_bind_{}", token.name.raw)),
+                            dispatch_through: Some(self.global_bind_fn.unwrap()),
+                            mangled_name: Some(format!(
+                                "starstream_bind_{}",
+                                token.name.uid.unwrap().id
+                            )),
                             ..Default::default()
                         },
                     );
@@ -731,8 +837,12 @@ impl Visitor {
                             }),
                             effects,
                             locals: vec![],
-                            is_main: false,
-                            mangled_name: Some(format!("starstream_unbind_{}", token.name.raw)),
+                            is_main: true,
+                            dispatch_through: Some(self.global_unbind_fn.unwrap()),
+                            mangled_name: Some(format!(
+                                "starstream_unbind_{}",
+                                token.name.uid.unwrap().id
+                            )),
                             ..Default::default()
                         },
                     );
@@ -748,15 +858,18 @@ impl Visitor {
                     self.push_function_declaration(
                         &mut mint.1,
                         FuncInfo {
-                            inputs_ty: vec![TypeArg::I64],
+                            inputs_ty: vec![TypeArg::U64],
                             output_ty: Some(TypeArg::Intermediate {
                                 abi: any.clone(),
                                 storage: any,
                             }),
                             effects,
                             locals: vec![],
-                            is_main: false,
-                            mangled_name: Some(format!("starstream_mint_{}", token.name.raw)),
+                            is_main: true,
+                            mangled_name: Some(format!(
+                                "starstream_mint_{}",
+                                token.name.uid.unwrap().id
+                            )),
                             ..Default::default()
                         },
                     );
@@ -1237,7 +1350,9 @@ impl Visitor {
                     let mut namespace = [&mut decl.interface];
                     self.resolve_name_in_namespace(&mut namespace, &mut decl.ident);
 
-                    let effect_id = decl.ident.uid.unwrap();
+                    let Some(effect_id) = decl.ident.uid else {
+                        return;
+                    };
 
                     let effect_info = self.symbols.effects.get(&effect_id).unwrap();
 
@@ -1871,12 +1986,12 @@ mod tests {
                         f.info
                             .mangled_name
                             .as_ref()
-                            .map(|name| name == "starstream_mint_MyToken")
+                            .map(|name| name.starts_with("starstream_mint_"))
                             .unwrap_or(false)
                     })
                     .unwrap();
 
-                assert_eq!(mint.info.inputs_ty, vec![TypeArg::I64]);
+                assert_eq!(mint.info.inputs_ty, vec![TypeArg::U64]);
 
                 let TypeArg::Intermediate { .. } = mint.info.output_ty.clone().unwrap() else {
                     panic!();

--- a/starstream_compiler/src/symbols.rs
+++ b/starstream_compiler/src/symbols.rs
@@ -48,6 +48,7 @@ pub struct TypeInfo {
     pub yield_ty: Option<TypeArg>,
     pub resume_ty: Option<TypeArg>,
     pub interfaces: EffectSet,
+    pub yield_fn: Option<SymbolId>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/starstream_compiler/src/symbols.rs
+++ b/starstream_compiler/src/symbols.rs
@@ -41,6 +41,7 @@ pub struct VarInfo {
 #[derive(Debug, Clone)]
 pub struct TypeInfo {
     pub declarations: HashSet<SymbolId>,
+
     pub storage: Option<Storage>,
     pub storage_ty: Option<ComparableType>,
     // TODO: may want to separate typedefs from utxo and token types
@@ -84,6 +85,25 @@ pub struct FuncInfo {
     //
     // currently it's set to the index of the first non-argument local.
     pub saved_frame_local_index: Option<u32>,
+
+    // currently bind and unbind are compiled as different functions, but
+    // dispatched through a single import
+    //
+    // this has the function id of that dispatcher
+    //
+    // there is most likely a better abstraction for this
+    pub dispatch_through: Option<SymbolId>,
+    pub is_imported: Option<&'static str>,
+
+    // TODO: other constant types
+    pub is_constant: Option<u64>,
+
+    // kind of hacky, since in theory this should depend on the type
+    //
+    // but for now it just makes things simpler
+    //
+    // this means the function moves the receiver when used in method form
+    pub moves_variable: bool,
 }
 
 pub type EffectHandlers = BTreeMap<SymbolId, ArgOrConst>;

--- a/starstream_vm/src/lib.rs
+++ b/starstream_vm/src/lib.rs
@@ -3,7 +3,6 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use byteorder::{LittleEndian, ReadBytesExt};
 pub use code::{CodeCache, CodeHash, ContractCode};
 use log::{debug, info, trace};
 use rand::RngCore;
@@ -146,17 +145,33 @@ enum Interrupt {
         name: String,
         inputs: Vec<Value>,
     },
-    // UTXO -> Token
-    TokenBind {
+    // Token 'constructor'
+    TokenMint {
         code: CodeHash,
         entry_point: String,
         inputs: Vec<Value>,
+        // some id for the token contract
+        // it should be something content-addressed eventually
+        token_type_id: u64,
+    },
+    // UTXO -> Token
+    TokenBind {
+        entry_point: String,
+        inputs: Vec<Value>,
+        token_id: TokenId,
     },
     TokenUnbind {
         token_id: TokenId,
         // Sanity checking - must match that of the token.
         //code: CodeHash,
-        //unbind_fn: String,
+        entry_point: String,
+    },
+    TokenBurn {
+        token_id: TokenId,
+    },
+    TokenSpend {
+        token_id: TokenId,
+        amount: u64,
     },
     GetTokens {
         data: u32,
@@ -188,7 +203,7 @@ fn starstream_eprint<T>(mut caller: Caller<T>, ptr: u32, len: u32) {
 
 /// Fulfiller of imports from `env`.
 #[allow(clippy::unused_unit)] // False positive. `clippy --fix` breaks the code.
-fn starstream_env<T>(linker: &mut Linker<T>, module: &str, this_code: &ContractCode) {
+fn starstream_env(linker: &mut Linker<TransactionInner>, module: &str, this_code: &ContractCode) {
     let this_code_hash = this_code.hash();
 
     linker
@@ -200,7 +215,7 @@ fn starstream_env<T>(linker: &mut Linker<T>, module: &str, this_code: &ContractC
         .func_wrap(
             module,
             "eprint",
-            |caller: Caller<T>, ptr: u32, len: u32| -> () {
+            |caller: Caller<TransactionInner>, ptr: u32, len: u32| -> () {
                 starstream_eprint(caller, ptr, len);
             },
         )
@@ -219,7 +234,7 @@ fn starstream_env<T>(linker: &mut Linker<T>, module: &str, this_code: &ContractC
         .func_wrap(
             module,
             "starstream_this_code",
-            move |mut caller: Caller<T>, return_addr: u32| {
+            move |mut caller: Caller<TransactionInner>, return_addr: u32| {
                 trace!("starstream_this_code({return_addr:#x})");
                 let (memory, _) = memory(&mut caller);
                 let hash = this_code_hash.raw();
@@ -232,7 +247,7 @@ fn starstream_env<T>(linker: &mut Linker<T>, module: &str, this_code: &ContractC
         .func_wrap(
             module,
             "starstream_keccak256",
-            |mut caller: Caller<T>, ptr: u32, len: u32, return_addr: u32| {
+            |mut caller: Caller<TransactionInner>, ptr: u32, len: u32, return_addr: u32| {
                 let mut hasher = tiny_keccak::Keccak::v256();
 
                 let (memory, _) = memory(&mut caller);
@@ -249,7 +264,7 @@ fn starstream_env<T>(linker: &mut Linker<T>, module: &str, this_code: &ContractC
         .func_wrap(
             module,
             "starstream_register_effect_handler",
-            move |mut caller: Caller<T>, ptr: u32, len: u32, handler_addr: i32| {
+            move |mut caller: Caller<TransactionInner>, ptr: u32, len: u32, handler_addr: i32| {
                 let (memory, _) = memory(&mut caller);
 
                 let name_slice = &memory[ptr as usize..(ptr + len) as usize];
@@ -266,7 +281,7 @@ fn starstream_env<T>(linker: &mut Linker<T>, module: &str, this_code: &ContractC
         .func_wrap(
             module,
             "starstream_unregister_effect_handler",
-            move |mut caller: Caller<T>, ptr: u32, len: u32| {
+            move |mut caller: Caller<TransactionInner>, ptr: u32, len: u32| {
                 let (memory, _) = memory(&mut caller);
 
                 let slice = &memory[ptr as usize..(ptr + len) as usize];
@@ -280,7 +295,7 @@ fn starstream_env<T>(linker: &mut Linker<T>, module: &str, this_code: &ContractC
         .func_wrap(
             module,
             "starstream_get_raised_effect_data",
-            move |mut caller: Caller<T>,
+            move |mut caller: Caller<TransactionInner>,
                   ptr: u32,
                   len: u32,
                   output_ptr_data: u32,
@@ -301,7 +316,7 @@ fn starstream_env<T>(linker: &mut Linker<T>, module: &str, this_code: &ContractC
         .func_wrap(
             module,
             "starstream_resume_throwing_program",
-            move |mut caller: Caller<T>, ptr: u32, len: u32, input_ptr_data: u32| {
+            move |mut caller: Caller<TransactionInner>, ptr: u32, len: u32, input_ptr_data: u32| {
                 let (memory, _) = memory(&mut caller);
 
                 let slice = &memory[ptr as usize..(ptr + len) as usize];
@@ -309,6 +324,67 @@ fn starstream_env<T>(linker: &mut Linker<T>, module: &str, this_code: &ContractC
                     name: String::from_utf8_lossy(slice).into_owned(),
                     input_ptr_data,
                 })
+            },
+        )
+        .unwrap();
+
+    linker
+        .func_wrap(
+            module,
+            "starstream_get_token_type",
+            |caller: Caller<TransactionInner>, token_id: i64| -> Result<u64, WasmiError> {
+                let token_id =
+                    TokenId::from_wasm(&Value::I64(token_id), caller.as_context()).unwrap();
+
+                let (_utxo, token) = caller.data().tokens.get(&token_id).unwrap();
+
+                Ok(token.token_type_id)
+            },
+        )
+        .unwrap();
+
+    linker
+        .func_wrap(
+            module,
+            "starstream_get_token_amount",
+            |caller: Caller<TransactionInner>, token_id: i64| -> Result<u64, WasmiError> {
+                let token_id =
+                    TokenId::from_wasm(&Value::I64(token_id), caller.as_context()).unwrap();
+
+                let (_utxo, token) = caller.data().tokens.get(&token_id).unwrap();
+
+                Ok(token.amount)
+            },
+        )
+        .unwrap();
+
+    linker
+        .func_wrap(
+            module,
+            "starstream_token_burn",
+            |caller: Caller<TransactionInner>, token_id: i64| -> Result<(), WasmiError> {
+                let token_id =
+                    TokenId::from_wasm(&Value::I64(token_id), caller.as_context()).unwrap();
+                host(Interrupt::TokenBurn { token_id })
+            },
+        )
+        .unwrap();
+
+    linker
+        .func_wrap(
+            module,
+            "starstream_token_spend",
+            |caller: Caller<TransactionInner>,
+             token_id: i64,
+             amount: i64|
+             -> Result<i64, WasmiError> {
+                let token_id =
+                    TokenId::from_wasm(&Value::I64(token_id), caller.as_context()).unwrap();
+                host(Interrupt::TokenSpend {
+                    token_id,
+                    amount: amount as u64,
+                })
+                .map(|_| unreachable!())
             },
         )
         .unwrap();
@@ -555,49 +631,39 @@ struct UtxoInstance {
 }
 */
 
-fn utxo_linker(
-    engine: &Engine,
-    code_cache: &Arc<CodeCache>,
-    utxo_code: &ContractCode,
-) -> Linker<TransactionInner> {
+fn utxo_linker(engine: &Engine, utxo_code: &ContractCode) -> Linker<TransactionInner> {
     let mut linker = Linker::<TransactionInner>::new(engine);
 
     starstream_env(&mut linker, "env", utxo_code);
 
     starstream_utxo_env(&mut linker, "starstream_utxo_env", utxo_code);
 
-    let current_code_hash = utxo_code.hash();
-
     for import in utxo_code.module(engine).imports() {
         if let ExternType::Func(func_ty) = import.ty() {
             if let Some(rest) = import.module().strip_prefix("starstream_token:") {
-                if import.name().starts_with("starstream_bind_") {
+                if import.name().starts_with("starstream_bind") {
                     let name = import.name().to_owned();
                     let rest = rest.to_owned();
-                    let code_cache = code_cache.clone();
                     linker
                         .func_new(
                             import.module(),
                             import.name(),
                             func_ty.clone(),
-                            move |_caller, inputs, _outputs| {
+                            move |caller, inputs, _outputs| {
                                 trace!("{rest}::{name}{inputs:?}");
 
-                                let code = if rest == "this" {
-                                    current_code_hash
-                                } else {
-                                    code_cache.load_debug(&rest).hash()
-                                };
+                                let token_id =
+                                    TokenId::from_wasm(&inputs[0], caller.as_context()).unwrap();
 
                                 host(Interrupt::TokenBind {
-                                    code,
                                     entry_point: name.clone(),
                                     inputs: inputs.to_vec(),
+                                    token_id,
                                 })
                             },
                         )
                         .unwrap();
-                } else if import.name().starts_with("starstream_unbind_") {
+                } else if import.name().starts_with("starstream_unbind") {
                     let name = import.name().to_owned();
                     let rest = rest.to_owned();
                     linker
@@ -612,7 +678,7 @@ fn utxo_linker(
                                 host(Interrupt::TokenUnbind {
                                     token_id,
                                     //hash,
-                                    //unbind_fn: name.clone(),
+                                    entry_point: name.clone(),
                                 })
                             },
                         )
@@ -655,10 +721,10 @@ fn token_linker(engine: &Engine, token_code: &Arc<ContractCode>) -> Linker<Trans
 
 // ----------------------------------------------------------------------------
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 struct Token {
-    bind_program: ProgramIdx,
-    id: u64,
+    program: ProgramIdx,
+    token_type_id: u64,
     amount: u64,
 }
 
@@ -834,6 +900,41 @@ fn coordination_script_linker(
                             },
                         )
                         .unwrap();
+                } else if import.name().starts_with("starstream_mint_") {
+                    let code_cache = code_cache.clone();
+
+                    // TODO: hacky
+                    // get as a parameter instead
+                    let token_type_id: u64 = import
+                        .name()
+                        .strip_prefix("starstream_mint_")
+                        .unwrap()
+                        .parse()
+                        .unwrap();
+
+                    linker
+                        .func_new(
+                            import.module(),
+                            import.name(),
+                            func_ty.clone(),
+                            move |_caller, inputs, _outputs| {
+                                trace!("{rest}::{name}{inputs:?}");
+
+                                let code = if rest == "this" {
+                                    current_code_hash
+                                } else {
+                                    code_cache.load_debug(&rest).hash()
+                                };
+
+                                host(Interrupt::TokenMint {
+                                    code,
+                                    entry_point: name.clone(),
+                                    inputs: inputs.to_vec(),
+                                    token_type_id,
+                                })
+                            },
+                        )
+                        .unwrap();
                 } else if import.name().starts_with("starstream_resume_") {
                     linker
                         .func_new(
@@ -950,7 +1051,7 @@ impl std::fmt::Debug for ProgramIdx {
 
 struct TxProgram {
     return_to: ProgramIdx,
-    return_is_token: bool,
+    return_is_token: Option<TokenId>,
     yield_to: Option<ProgramIdx>,
     yield_to_constructor: Option<Value>,
 
@@ -1139,6 +1240,7 @@ mod serde_value_vec {
 #[derive(Default)]
 struct TransactionInner {
     utxos: HashMap<UtxoId, Utxo>,
+    tokens: HashMap<TokenId, (Option<UtxoId>, Token)>,
     temporary_utxo_ids: HashMap<u64, UtxoId>,
     temporary_token_ids: HashMap<u64, TokenId>,
 
@@ -1265,46 +1367,13 @@ impl Transaction {
                         return result;
                     }
 
-                    let mut read_from_memory = vec![];
-                    if self.store.data().programs[from_program.0].return_is_token {
-                        // Transform id & amount in memory into [TokenId]. Kind of awkward?
-                        let instance = self.store.data().programs[from_program.0].instance;
-                        let memory = instance
-                            .get_export(&self.store, "memory")
-                            .unwrap()
-                            .into_memory()
-                            .unwrap()
-                            .data(&self.store);
-
-                        let addr = if self.rust_compat { 16usize } else { 0usize };
-                        let segment = MemorySegment {
-                            address: addr as u32,
-                            data: memory[addr..addr + 16].to_vec(),
-                        };
-                        let mut cursor = &segment.data[..];
-                        let id = cursor.read_u64::<LittleEndian>().unwrap();
-                        let amount = cursor.read_u64::<LittleEndian>().unwrap();
-                        read_from_memory.push(segment);
-
-                        let token_id = TokenId::random();
-                        let token = Token {
-                            // code and unbind_fn can be determined by the bind() program
-                            bind_program: from_program,
-                            id,
-                            amount,
-                        };
-                        let utxo_id = self.store.data_mut().programs[to_program.0].utxo.unwrap();
-                        self.store
-                            .data_mut()
-                            .utxos
-                            .get_mut(&utxo_id)
-                            .unwrap()
-                            .tokens
-                            .insert(token_id, token);
+                    if let Some(token_id) =
+                        self.store.data().programs[from_program.0].return_is_token
+                    {
                         values = vec![token_id.to_wasm_i64(self.store.as_context_mut())];
                     }
 
-                    self.resume(from_program, to_program, values, read_from_memory, vec![])
+                    self.resume(from_program, to_program, values, vec![], vec![])
                 }
 
                 // ------------------------------------------------------------
@@ -1452,7 +1521,7 @@ impl Transaction {
                     inputs,
                 }) => {
                     let code = self.code_cache.get(code_hash);
-                    let linker = utxo_linker(self.store.engine(), &self.code_cache, &code);
+                    let linker = utxo_linker(self.store.engine(), &code);
                     let id = UtxoId::random();
 
                     let (to_program, result) =
@@ -1630,37 +1699,65 @@ impl Transaction {
 
                     self.call_method(from_program, to_program, method, inputs)
                 }
-                Err(Interrupt::TokenBind {
+
+                Err(Interrupt::TokenMint {
                     code,
                     entry_point,
-                    mut inputs,
+                    inputs,
+                    token_type_id,
                 }) => {
                     let code = self.code_cache.get(code);
                     let linker = token_linker(self.store.engine(), &code);
-                    //let id = TokenId::random();
+                    let id = TokenId::random();
 
-                    // Prepend TokenStorage struct return address to inputs.
-                    // HACK: The 16 here is a low but nonzero memory address
-                    // that we're crossing our fingers and hoping that the WASM
-                    // doesn't actually use.
-                    // BETTER: Extend the WASM memory with a new page that we
-                    // know won't collide because it didn't exist before,
-                    // and return there (downside: uses more memory).
-                    // BEST: Use WASM multivalues (Rust -Ctarget-feature=+multivalue)
-                    // instead of struct return addresses in the first place.
-                    // TODO: Memory trace this or fix the hack described above.
-                    if self.rust_compat {
-                        let return_addr: usize = 16;
-                        inputs.insert(0, Value::I32(return_addr as i32));
-                    }
+                    let amount = match &inputs[0] {
+                        Value::I64(amount) => *amount as u64,
+                        _ => unreachable!(),
+                    };
 
                     let (to_program, result) =
                         self.start_program(from_program, &linker, &code, &entry_point, inputs);
-                    self.store.data_mut().programs[to_program.0].return_is_token = true;
+
+                    let token = Token {
+                        program: to_program,
+                        token_type_id,
+                        amount,
+                    };
+
+                    self.store.data_mut().tokens.insert(id, (None, token));
+
+                    self.store.data_mut().programs[to_program.0].return_is_token = Some(id);
 
                     (to_program, result)
                 }
-                Err(Interrupt::TokenUnbind { token_id }) => {
+                Err(Interrupt::TokenBind {
+                    entry_point,
+                    inputs,
+                    token_id,
+                }) => {
+                    let utxo_id = self.store.data_mut().programs[from_program.0].utxo.unwrap();
+                    let (_, token) = self.store.data_mut().tokens.get(&token_id).unwrap();
+                    let token = *token;
+
+                    let entry_point = format!("{}_{}", entry_point, token.token_type_id);
+
+                    let (to_program, result) =
+                        self.call_method(from_program, from_program, entry_point, inputs);
+
+                    self.store
+                        .data_mut()
+                        .utxos
+                        .get_mut(&utxo_id)
+                        .unwrap()
+                        .tokens
+                        .insert(token_id, token);
+
+                    (to_program, result)
+                }
+                Err(Interrupt::TokenUnbind {
+                    token_id,
+                    entry_point: unbind_fn,
+                }) => {
                     // assume that only the utxo that owns the token can unbind it?
                     let utxo_id = self.store.data_mut().programs[from_program.0].utxo.unwrap();
 
@@ -1674,25 +1771,41 @@ impl Transaction {
                         .remove(&token_id)
                         .unwrap();
 
-                    let code = self.store.data().programs[token.bind_program.0].code;
-                    let code = self.code_cache.get(code);
+                    let entry_point = format!("{}_{}", unbind_fn, token.token_type_id);
 
-                    let entry_point = self.store.data().programs[token.bind_program.0]
-                        .entry_point
-                        .replace("bind", "unbind");
+                    self.call_method(from_program, from_program, entry_point, vec![])
+                }
+                Err(Interrupt::TokenBurn { token_id }) => {
+                    let to_program = from_program;
 
-                    let linker = token_linker(self.store.engine(), &code);
+                    let data_mut = self.store.data_mut();
 
-                    let inputs = if self.rust_compat {
-                        vec![Value::I64(token.id as i64), Value::I64(token.amount as i64)]
-                    } else {
-                        vec![]
-                    };
+                    if let Some((utxo, _)) = data_mut.tokens.remove(&token_id) {
+                        assert!(utxo.is_none(), "can't burn token without unbinding first");
+                    }
 
-                    let (to_program, result) =
-                        self.start_program(from_program, &linker, &code, &entry_point, inputs);
+                    self.resume(from_program, to_program, vec![], vec![], vec![])
+                }
+                Err(Interrupt::TokenSpend { token_id, amount }) => {
+                    let to_program = from_program;
 
-                    (to_program, result)
+                    let data_mut = self.store.data_mut();
+
+                    let new_token_id = TokenId::random();
+                    if let Some((utxo, token)) = data_mut.tokens.get_mut(&token_id) {
+                        assert!(utxo.is_none(), "can't split token without unbinding first");
+
+                        let mut new_token = *token;
+                        new_token.amount = amount;
+
+                        token.amount = token.amount.checked_sub(amount).unwrap();
+
+                        data_mut.tokens.insert(new_token_id, (None, new_token));
+                    }
+
+                    let new_token_id = new_token_id.to_wasm_i64(self.store.as_context_mut());
+
+                    self.resume(from_program, to_program, vec![new_token_id], vec![], vec![])
                 }
                 Err(Interrupt::GetTokens {
                     data,
@@ -1775,7 +1888,7 @@ impl Transaction {
         let fuel = self.store.fuel_consumed().unwrap();
         let main = instance
             .get_func(&mut self.store, entry_point)
-            .expect(&entry_point);
+            .expect(entry_point);
         let num_outputs = main.ty(&mut self.store).results().len();
         let mut outputs = [Value::from(ExternRef::null())];
         let resumable = main
@@ -1797,7 +1910,7 @@ impl Transaction {
         debug!("= {result:?}");
         self.store.data_mut().programs.push(TxProgram {
             return_to: from_program,
-            return_is_token: false,
+            return_is_token: None,
             yield_to: None,
             yield_to_constructor: None,
             code: code.hash(),
@@ -1937,7 +2050,7 @@ impl Transaction {
         let utxo = self.store.data().programs[to_program.0].utxo;
         self.store.data_mut().programs.push(TxProgram {
             return_to: from_program,
-            return_is_token: false,
+            return_is_token: None,
             yield_to: None,
             yield_to_constructor: None,
             code,

--- a/starstream_vm/tests/test_codegen_token_binding.rs
+++ b/starstream_vm/tests/test_codegen_token_binding.rs
@@ -1,0 +1,50 @@
+use starstream_vm::*;
+use tempfile::TempDir;
+
+#[test]
+pub fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();
+
+    let output_dir = TempDir::new().unwrap();
+
+    let mut output_path = output_dir.path().to_path_buf();
+    output_path.push("codegen.wasm");
+
+    let output = std::process::Command::new("cargo")
+        .arg("run")
+        .arg("--bin")
+        .arg("starstream")
+        .arg("compile")
+        .arg("-c")
+        .arg("grammar/examples/tokens.star")
+        .arg("-o")
+        .arg(&output_path)
+        .current_dir("../")
+        .output()
+        .unwrap();
+
+    std::process::Command::new("wasm2wat")
+        .arg("--no-check")
+        .arg(&output_path)
+        .spawn()
+        .unwrap()
+        .wait()
+        .unwrap();
+
+    std::process::Command::new("wasm2wat")
+        .arg(&output_path)
+        .spawn()
+        .unwrap()
+        .wait()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let mut tx = Transaction::new();
+
+    let contract = tx.code_cache().load_file(&output_path);
+
+    tx.run_coordination_script(&contract, "main", vec![]);
+
+    // tx.prove();
+}

--- a/starstream_vm/tests/test_codegen_token_binding.rs
+++ b/starstream_vm/tests/test_codegen_token_binding.rs
@@ -23,20 +23,20 @@ pub fn main() {
         .output()
         .unwrap();
 
-    std::process::Command::new("wasm2wat")
-        .arg("--no-check")
-        .arg(&output_path)
-        .spawn()
-        .unwrap()
-        .wait()
-        .unwrap();
+    // std::process::Command::new("wasm2wat")
+    //     .arg("--no-check")
+    //     .arg(&output_path)
+    //     .spawn()
+    //     .unwrap()
+    //     .wait()
+    //     .unwrap();
 
-    std::process::Command::new("wasm2wat")
-        .arg(&output_path)
-        .spawn()
-        .unwrap()
-        .wait()
-        .unwrap();
+    // std::process::Command::new("wasm2wat")
+    //     .arg(&output_path)
+    //     .spawn()
+    //     .unwrap()
+    //     .wait()
+    //     .unwrap();
 
     assert!(output.status.success());
 

--- a/starstream_vm/tests/test_example_contract.rs
+++ b/starstream_vm/tests/test_example_contract.rs
@@ -1,6 +1,7 @@
 use starstream_vm::*;
 use wasmi::Value;
 
+#[ignore]
 #[test]
 pub fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();

--- a/starstream_vm/tests/test_permissioned.rs
+++ b/starstream_vm/tests/test_permissioned.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use starstream_vm::*;
 use wasmi::Value;
 
+#[ignore]
 #[test]
 pub fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();

--- a/starstream_vm/tests/test_proving.rs
+++ b/starstream_vm/tests/test_proving.rs
@@ -1,5 +1,6 @@
 use starstream_vm::*;
 
+#[ignore]
 #[test]
 pub fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();

--- a/website/src/examples.ts
+++ b/website/src/examples.ts
@@ -2,6 +2,7 @@ import hello from "file-loader!../../grammar/examples/hello_world.star";
 import payToPublicKeyHash from "file-loader!../../grammar/examples/pay_to_public_key_hash.star";
 import simpleOracle from "file-loader!../../grammar/examples/simple_oracle.star";
 import effectHandlers from "file-loader!../../grammar/examples/effect_handlers.star";
+import tokens from "file-loader!../../grammar/examples/tokens.star";
 import oracle from "file-loader!../../grammar/examples/oracle.star";
 import permissionedToken from "file-loader!../../grammar/examples/permissioned_usdc.star";
 import event from "file-loader!../../grammar/examples/event.star";
@@ -35,6 +36,7 @@ export default {
   PayToPublicKeyHash: cache(fetchCode(payToPublicKeyHash)),
   "Simple Oracle": cache(fetchCode(simpleOracle)),
   "Effect Handlers": cache(fetchCode(effectHandlers)),
+  "Token api": cache(fetchCode(tokens)),
   Oracle: cache(fetchCode(oracle)),
   "Permissioned Token": cache(fetchCode(permissionedToken)),
 } as Record<string, () => Promise<string>>;


### PR DESCRIPTION
This includes a few unrelated things, but in general the goal of this PR is to add the codegen + VM api that was needed to make the `grammar/examples/token.star`  to run, and it was easier to just test things together. I think reading that example (either here or on the sandbox) explains this PR more or less.

The unfortunate thing is that this breaks the rust-based examples. And I don't think it's worth spending the time updating those. But open to opinions.

# API changes (syscalls/ledger ops)

## Add starstream_mint_{token_id}(token_class, amount) -> Intermediate

Now each token has to export a `starstream_mint_{token_id}`, and the imported function dispatches to that.

The function currently receives the `amount` in the token storage. I ignored the NFT-id for now, but it would be easy to add.

The reasoning for this new call, is that previously mint was just an arbitrary function not invoked by the system. This means there wasn't really any proof that you created that through the mint function. The idea now is that the handle (which is now the Intermediate) acts as a certificate that the mint function was actually executed.

NOTE: to prove that all intermediates are bound at the end of the transaction, maybe the mint function should write to an `unitialized` tokens field or something, but it's too early to think about that.

Also the token information includes an id for the token instance (each `token Name {}` in the DSL). Right now this is extracted in a hacky way, but eventually we should be able to use the hash of the token definition or something, and maybe pass that as a parameter.

## Make starstream_bind and starstream_unbind polymorphic

Now there is a single import for `starstream_bind` and `starstream_unbind`. Instead of defining one import per token.

The exports are the same, with one export per token per function. The dispatch can be done by the VM because during `mint` we already register which type of token is associated with that intermediate.

The reasoning for this change is that these functions are supposed to be handled polymorphically. Binding and unbinding should depend on the ABI (interface) of the tokens, not on the instances. Otherwise a module would have to be re-compiled to support each new token with the same ABI. Doesn't matter now that everything is in a single file, but in theory we could dynamically load the bind and unbind function without having to modify the contract's definition.

#### OPEN QUESTION

I don't know how to make the above work with tokens that have effects in bind or unbind though. Currently this is not supported anyway, but it's something that needs to be addressed.

The problem is that currently the effect handlers are passed as parameters, and wasm functions can only have fixed arity. This means we would need an exponential (2^effects) number of `bind` functions to support all the combinations.

Most likely the solution is to encode the effect handlers as a dynamic dictionary in memory (on the stack hopefully), but maybe there is a simpler fix. Especially because there won't be shared memory between the `bind` function and the `utxo`, so it would have to be setup through syscalls somehow.

## Add starstream_token_burn(token_id)

Self explanatory. Since intermediates are linear types, I needed someway of consuming them in some branches.

Maybe this can be unified with `starstream_consume` for a simpler api for both tokens and utxos.

## Add starstream_token_amount(token_id): u64

`intermediate.amount()`

## Add starstream_token_type(token_id)

Since intermediates are polymorphic, this allow branching on them with `Token::id() == intermediate.type()`

## Add starstream_token_spend(token_id, amount): Intermediate

A split function. Maybe this is not the proper api, but at least to have something that allows us to write transaction balancing logic.

# Misc changes

## Add builtin unbind_utxo_tokens function

This function can't really be written right now with the DSL primitives. So I just wrote it in wasm as a builtin.

Eventually it could be an import.

It can be inserted to unbind all the tokens in the utxo, and call the `StarstreamToken::TokenUnbound` effect with the intermediate.


## Improved the linear typechecking code a bit

Mostly just made it so a few "methods" don't move the variable for convenience. This will still need work later.

## Fixed a bug where resuming a utxo didn't update the effect handlers

Now there is a `resume` function per utxo. Because it has different arity depending on the effects of that utxo.

This allows having different handlers for `new` and `resume` (and any subsequent resume).

This was just something I overlooked before. 
